### PR TITLE
docs(P1): standardize GIJ front matter and update badges

### DIFF
--- a/git-integration-for-jira-cloud/Deeplinking-feature-gij-cloud.md
+++ b/git-integration-for-jira-cloud/Deeplinking-feature-gij-cloud.md
@@ -1,11 +1,22 @@
 ---
-
-title: Deep Linking
-description: Learn how to use deep linking in Git Integration for Jira Cloud to open repositories, commits, branches, and tags in GitKraken or GitLens.
+title: "Deep Linking"
+description: "Learn how to use deep linking in Git Integration for Jira Cloud to open repositories, commits, branches, and tags in GitKraken or GitLens."
+product: "Git Integration for Jira Cloud"
+feature: "Deep Linking"
+content_type: "concept"
+audience: "admin"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "Jira Administrator"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "concept", "admin"]
 taxonomy:
     category: git-integration-for-jira-cloud
-
 ---
+<kbd>Last updated: March 2026</kbd>
 
 <b style='background-color:#EAE5FE; padding:1px 5px; color:#412C92; border-radius:3px; margin: 0 5px; font-size: small;'>NEW FEATURE</b>
 <br>
@@ -163,5 +174,3 @@ Jira administrators can enable or disable this feature for all Jira users. Indiv
 2. Enable or disable this setting under the **GitLens integration** section.
 
 <img src='/wp-content/uploads/gij-gitcloud-deeplink-gitkraken-user-settings-2025.png'  style='margin:25px auto;display:block;' alt='Access the GitKraken integration option to enable/disable the feature in the User settings (sidebar) of the Git Integration for Jira app' />
-
-<kbd>Last updated: December 2025</kbd>

--- a/git-integration-for-jira-cloud/Documentation-gij-cloud.md
+++ b/git-integration-for-jira-cloud/Documentation-gij-cloud.md
@@ -1,11 +1,22 @@
 ---
-
-title: Documentation
-description: Complete documentation for Git Integration for Jira Cloud
+title: "Documentation"
+description: "Complete documentation for Git Integration for Jira Cloud"
+product: "Git Integration for Jira Cloud"
+feature: "Documentation"
+content_type: "reference"
+audience: "admin"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "Jira Administrator"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "reference", "admin"]
 taxonomy:
     category: git-integration-for-jira-cloud
-
 ---
+<kbd>Last updated: March 2026</kbd>
 
 <img src='/wp-content/uploads/gij-docs-introduction-bbb-overview_708.png' height=auto width=100% />
 
@@ -159,5 +170,3 @@ Documentation terms and glossary.
 Legal information about license and copyright notice.
 
 <p>&nbsp;</p>
-
-<p style="text-align: center; margin: 0; padding: 0;"><kbd>Last updated: December 2025</kbd></p>

--- a/git-integration-for-jira-cloud/End-User-Guide-cloud.md
+++ b/git-integration-for-jira-cloud/End-User-Guide-cloud.md
@@ -1,11 +1,22 @@
 ---
-
-title: User Guide - GIJ Cloud
-description: End user guide for Git Integration for Jira Cloud - learn how to view and create Git data in Jira
+title: "User Guide - GIJ Cloud"
+description: "End user guide for Git Integration for Jira Cloud - learn how to view and create Git data in Jira"
+product: "Git Integration for Jira Cloud"
+feature: "User Guide - GIJ Cloud"
+content_type: "concept"
+audience: "developer"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "User"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "concept", "developer"]
 taxonomy:
     category: git-integration-for-jira-cloud
-
 ---
+<kbd>Last updated: March 2026</kbd>
 
 ## Introduction to GIJ
 
@@ -153,5 +164,3 @@ See [Creating Personal Access Tokens](/git-integration-for-jira-cloud/creating-p
 ![PAT](/wp-content/uploads/GIJ-Cloud-User-Settings-PAT.png)
 
 <p>&nbsp;</p>
-
-<p style="text-align: center; margin: 0; padding: 0;"><kbd>Last updated: December 2025</kbd></p>

--- a/git-integration-for-jira-cloud/Fix-for-empty-JSON-files-gij-cloud.md
+++ b/git-integration-for-jira-cloud/Fix-for-empty-JSON-files-gij-cloud.md
@@ -1,9 +1,22 @@
 ---
-title: Fix for empty JSON files
-description: Troubleshooting guide for corrupted JSON configuration files in Git Integration for Jira Cloud.
+title: "Fix for empty JSON files"
+description: "Troubleshooting guide for corrupted JSON configuration files in Git Integration for Jira Cloud."
+product: "Git Integration for Jira Cloud"
+feature: "Fix for empty JSON files"
+content_type: "troubleshooting"
+audience: "all"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "all"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "troubleshooting"]
 taxonomy:
     category: git-integration-for-jira-cloud
 ---
+<kbd>Last updated: March 2026</kbd>
 
 This page provides solutions for recovering from corrupted integration configuration files.
 
@@ -86,5 +99,3 @@ Unexpected file corruption of the JSON file that stores integration and reposito
     </div>
     </div>
 </div>
-
-<kbd>Last updated: December 2025</kbd>

--- a/git-integration-for-jira-cloud/GIJ Standard vs Advanced Features.md
+++ b/git-integration-for-jira-cloud/GIJ Standard vs Advanced Features.md
@@ -1,11 +1,23 @@
 ---
-
-title: GIJ Standard vs Advanced Feature matrix
-description: New Doc Description
+title: "GIJ Standard vs Advanced Feature matrix"
+description: "Reference documentation for GIJ Standard vs Advanced Feature matrix in Git Integration for Jira Cloud, for Jira users and developers."
+product: "Git Integration for Jira Cloud"
+feature: "GIJ Standard vs Advanced Feature matrix"
+content_type: "reference"
+audience: "developer"
+plan_required: "Standard, Advanced"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "User"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "reference", "developer", "Standard, Advanced"]
 taxonomy:
     category: git-integration-for-jira-cloud
-
 ---
+<kbd>Last updated: March 2026</kbd>
+
 # Feature availability between versions
 
 | Feature | Standard | Advanced |

--- a/git-integration-for-jira-cloud/GIJ Standard vs Advanced.md
+++ b/git-integration-for-jira-cloud/GIJ Standard vs Advanced.md
@@ -1,11 +1,22 @@
 ---
-
-title: GIJ Standard vs Advanced
-description: Learn about the differences between the Standard and Advanced versions of Git Integration for Jira
+title: "GIJ Standard vs Advanced"
+description: "Learn about the differences between the Standard and Advanced versions of Git Integration for Jira"
+product: "Git Integration for Jira Cloud"
+feature: "GIJ Standard vs Advanced"
+content_type: "integration"
+audience: "all"
+plan_required: "Standard, Advanced"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "all"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "integration", "Standard, Advanced"]
 taxonomy:
     category: git-integration-for-jira-cloud
-
 ---
+<kbd>Last updated: March 2026</kbd>
 
 Git Integration for Jira (GIJ) Advanced is a higher-tier edition designed for organizations that need greater indexing performance, reduced maintenance, and enhanced monitoring capabilities. Product and Engineering teams use the Advanced edition to monitor risks and consistently meet deadlines. Advanced edition users also benefit from higher configuration limits for repositories.
 
@@ -64,5 +75,3 @@ For a detailed breakdown of feature differences between the two editions, see [G
 </div>
 
 <p>&nbsp;</p>
-
-<p style="text-align: center; margin: 0; padding: 0;"><kbd>Last updated: December 2025</kbd></p>

--- a/git-integration-for-jira-cloud/GIJ-Advanced-Support-Guide.md
+++ b/git-integration-for-jira-cloud/GIJ-Advanced-Support-Guide.md
@@ -1,9 +1,22 @@
 ---
-title: GIJ Advanced Support Guide
-description: Guidelines for submitting priority support requests for GIJ Advanced edition.
+title: "GIJ Advanced Support Guide"
+description: "Guidelines for submitting priority support requests for GIJ Advanced edition."
+product: "Git Integration for Jira Cloud"
+feature: "GIJ Advanced Support Guide"
+content_type: "troubleshooting"
+audience: "admin"
+plan_required: "Advanced"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "Jira Administrator"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "troubleshooting", "admin", "Advanced"]
 taxonomy:
     category: git-integration-for-jira-cloud
 ---
+<kbd>Last updated: March 2026</kbd>
 
 GIJ Advanced Edition provides priority support with an initial response within 6 business hours*.
 
@@ -59,5 +72,3 @@ Copy the information at the bottom of the page starting from "Current Build". In
 ---
 
 *During support team business hours (10:00-22:00 UTC, Monday-Friday). See our [GIJ Cloud Support Terms and Services](https://help.gitkraken.com/git-integration-for-jira-cloud/sla-terms-and-conditions-gij-cloud/#git-integration-for-jira-cloud-support) for details.
-
-<kbd>Last updated: December 2025</kbd>

--- a/git-integration-for-jira-cloud/GIJ-Advanced-Support-form.md
+++ b/git-integration-for-jira-cloud/GIJ-Advanced-Support-form.md
@@ -1,9 +1,22 @@
 ---
-title: GIJ Advanced Support Form
-description: Submit a support request for GIJ Advanced edition.
+title: "GIJ Advanced Support Form"
+description: "Submit a support request for GIJ Advanced edition."
+product: "Git Integration for Jira Cloud"
+feature: "GIJ Advanced Support Form"
+content_type: "admin"
+audience: "admin"
+plan_required: "Advanced"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "Jira Administrator"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "admin", "Advanced"]
 taxonomy:
     category: git-integration-for-jira-cloud
 ---
+<kbd>Last updated: March 2026</kbd>
 
 See the [GIJ Advanced Support Guide](https://help.gitkraken.com/git-integration-for-jira-cloud/GIJ-Advanced-Support-Guide) for details on what information to include with your request and how to gather it.
 
@@ -15,5 +28,3 @@ See the [GIJ Advanced Support Guide](https://help.gitkraken.com/git-integration-
     region: "na1"
   });
 </script>
-
-<kbd>Last updated: December 2025</kbd>

--- a/git-integration-for-jira-cloud/GIJ-Cloud-New-Doc.md
+++ b/git-integration-for-jira-cloud/GIJ-Cloud-New-Doc.md
@@ -1,8 +1,21 @@
 ---
-
-title: New Doc Title
-description: New Doc Description
+title: "New Doc Title"
+description: "Step-by-step guide to New Doc Title in Git Integration for Jira Cloud, for Jira Cloud users."
+product: "Git Integration for Jira Cloud"
+feature: "New Doc Title"
+content_type: "integration"
+audience: "all"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "all"
+version_required: "all"
+status: "draft"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "integration", "draft"]
 taxonomy:
     category: git-integration-for-jira-cloud
-
 ---
+<kbd>Last updated: March 2026</kbd>
+
+

--- a/git-integration-for-jira-cloud/Getting-Started-Guide-App-operations-and-planning.md
+++ b/git-integration-for-jira-cloud/Getting-Started-Guide-App-operations-and-planning.md
@@ -1,11 +1,22 @@
 ---
-
-title: Application Operations and Planning
-description: Understanding integration types, indexing behavior, and planning your Git Integration for Jira structure
+title: "Application Operations and Planning"
+description: "Understanding integration types, indexing behavior, and planning your Git Integration for Jira structure"
+product: "Git Integration for Jira Cloud"
+feature: "Application Operations and Planning"
+content_type: "install"
+audience: "admin"
+plan_required: "Standard, Advanced"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "Jira Administrator"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "install", "admin", "Standard, Advanced"]
 taxonomy:
     category: git-integration-for-jira-cloud
-
 ---
+<kbd>Last updated: March 2026</kbd>
 
 ## Integration Types
 
@@ -111,5 +122,3 @@ Rate limiting can become an issue for large instances with many repositories or 
 [<b style='background-color:#F1F1F1; padding:1px 5px; color:#181D28; border-radius:3px; margin: 0 5px; font-size: medium;'>PREVIOUS</b>](/git-integration-for-jira-cloud/Getting-Started-Guide/) <a href="https://help.gitkraken.com/git-integration-for-jira-cloud/Getting-Started-Guide/">Getting Started</a>
 
 <p>&nbsp;</p>
-
-<p style="text-align: center; margin: 0; padding: 0;"><kbd>Last updated: December 2025</kbd></p>

--- a/git-integration-for-jira-cloud/Getting-Started-Guide-Integration-Creation-Post-Integration-Config.md
+++ b/git-integration-for-jira-cloud/Getting-Started-Guide-Integration-Creation-Post-Integration-Config.md
@@ -1,11 +1,22 @@
 ---
-
-title: Integration Creation and Post Integration Configuration
-description: Step-by-step guidance for creating integrations and configuring post-integration settings
+title: "Integration Creation and Post Integration Configuration"
+description: "Step-by-step guidance for creating integrations and configuring post-integration settings"
+product: "Git Integration for Jira Cloud"
+feature: "Integration Creation and Post Integration Configuration"
+content_type: "integration"
+audience: "admin"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "Jira Administrator"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "integration", "admin"]
 taxonomy:
     category: git-integration-for-jira-cloud
-
 ---
+<kbd>Last updated: March 2026</kbd>
 
 ## Integration Creation
 
@@ -69,5 +80,3 @@ See [Require Personal Access Tokens](/git-integration-for-jira-cloud/require-per
 [<b style='background-color:#F1F1F1; padding:1px 5px; color:#181D28; border-radius:3px; margin: 0 5px; font-size: medium;'>PREVIOUS</b>](/git-integration-for-jira-cloud/Getting-Started-Guide-App-operations-and-planning/) <a href="https://help.gitkraken.com/git-integration-for-jira-cloud/Getting-Started-Guide-App-operations-and-planning/">Application Operations and Planning</a>
 
 <p>&nbsp;</p>
-
-<p style="text-align: center; margin: 0; padding: 0;"><kbd>Last updated: December 2025</kbd></p>

--- a/git-integration-for-jira-cloud/Getting-Started-Guide-Optional-Features.md
+++ b/git-integration-for-jira-cloud/Getting-Started-Guide-Optional-Features.md
@@ -1,11 +1,22 @@
 ---
-
-title: Optional Features and Add-on Extensions
-description: Explore optional features and free add-on applications that extend Git Integration for Jira functionality
+title: "Optional Features and Add-on Extensions"
+description: "Explore optional features and free add-on applications that extend Git Integration for Jira functionality"
+product: "Git Integration for Jira Cloud"
+feature: "Optional Features and Add-on Extensions"
+content_type: "install"
+audience: "admin"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "Jira Administrator"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "install", "admin"]
 taxonomy:
     category: git-integration-for-jira-cloud
-
 ---
+<kbd>Last updated: March 2026</kbd>
 
 Congratulations! You have successfully completed your base GIJ configuration. The following features and free add-on extension applications aren't required for GIJ to operate, but they provide additional value on top of the base functionality. We recommend exploring them.
 
@@ -44,5 +55,3 @@ Team Insights for Jira is a free standalone application designed for planning an
 [<b style='background-color:#F1F1F1; padding:1px 5px; color:#181D28; border-radius:3px; margin: 0 5px; font-size: medium;'>PREVIOUS</b>](/git-integration-for-jira-cloud/Getting-Started-Guide-Integration-Creation-Post-Integration-Config/) <a href="https://help.gitkraken.com/git-integration-for-jira-cloud/Getting-Started-Guide-Integration-Creation-Post-Integration-Config/">Integration Creation and Post Integration Configuration</a>
 
 <p>&nbsp;</p>
-
-<p style="text-align: center; margin: 0; padding: 0;"><kbd>Last updated: December 2025</kbd></p>

--- a/git-integration-for-jira-cloud/Getting-Started-Guide.md
+++ b/git-integration-for-jira-cloud/Getting-Started-Guide.md
@@ -1,11 +1,22 @@
 ---
-
-title: Admin Getting Started Guide
-description: Essential configuration guide for Jira Admins setting up Git Integration for Jira Cloud
+title: "Admin Getting Started Guide"
+description: "Essential configuration guide for Jira Admins setting up Git Integration for Jira Cloud"
+product: "Git Integration for Jira Cloud"
+feature: "Admin Getting Started Guide"
+content_type: "concept"
+audience: "admin"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "Jira Administrator"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "concept", "admin"]
 taxonomy:
     category: git-integration-for-jira-cloud
-
 ---
+<kbd>Last updated: March 2026</kbd>
 
 ## Application Overview
 
@@ -60,5 +71,3 @@ Use [Project Association Permissions](/git-integration-for-jira-cloud/setting-pr
 [<b style='background-color:#FFFCC3; padding:1px 5px; color:#181D28; border-radius:3px; margin: 0 5px; font-size: medium;'>NEXT</b>](/git-integration-for-jira-cloud/Getting-Started-Guide-App-operations-and-planning) <a href="https://help.gitkraken.com/git-integration-for-jira-cloud/Getting-Started-Guide-App-operations-and-planning/">Application Operations and Integration Structure Planning</a>
 
 <p>&nbsp;</p>
-
-<p style="text-align: center; margin: 0; padding: 0;"><kbd>Last updated: December 2025</kbd></p>

--- a/git-integration-for-jira-cloud/SLA-terms-and-conditions-gij-cloud.md
+++ b/git-integration-for-jira-cloud/SLA-terms-and-conditions-gij-cloud.md
@@ -1,9 +1,22 @@
 ---
-title: GIJ Terms and Conditions
-description: Support coverage, commitments, and service level agreements for Git Integration for Jira.
+title: "GIJ Terms and Conditions"
+description: "Support coverage, commitments, and service level agreements for Git Integration for Jira."
+product: "Git Integration for Jira Cloud"
+feature: "GIJ Terms and Conditions"
+content_type: "integration"
+audience: "all"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "all"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "integration"]
 taxonomy:
     category: git-integration-for-jira-cloud
 ---
+<kbd>Last updated: March 2026</kbd>
 
 GitKraken's goal is to ensure you can use Git Integration for Jira (GIJ) effortlessly and with minimal friction. This page covers terms and conditions for Git Integration for Jira Cloud.
 
@@ -113,5 +126,3 @@ GitKraken adheres to Atlassian's deprecation and support timelines for Jira Clou
     </div>
     </div>
 </div>
-
-<kbd>Last updated: December 2025</kbd>

--- a/git-integration-for-jira-cloud/Signals-backlog-view-gij-cloud.md
+++ b/git-integration-for-jira-cloud/Signals-backlog-view-gij-cloud.md
@@ -1,11 +1,22 @@
 ---
-
-title: Signals Backlog View
-description: Learn how to use the Backlog View in Signals to track sprint progress, identify work risks, and manage backlog priorities.
+title: "Signals Backlog View"
+description: "Learn how to use the Backlog View in Signals to track sprint progress, identify work risks, and manage backlog priorities."
+product: "Git Integration for Jira Cloud"
+feature: "Signals Backlog View"
+content_type: "concept"
+audience: "all"
+plan_required: "Advanced"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "all"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "concept", "Advanced"]
 taxonomy:
     category: git-integration-for-jira-cloud
-
 ---
+<kbd>Last updated: March 2026</kbd>
 
 <div class='embed-container embed-container--16-9'>
     <iframe width='709' height='382' src='https://www.youtube.com/embed/nxp_D7UuVU8' frameborder='0' allowfullscreen ></iframe>
@@ -254,5 +265,3 @@ Sortable columns include:
 [Pull request timeline reindex](/git-integration-for-jira-cloud/pull-request-timeline-for-Signals-gij-cloud/)
 
 <p>&nbsp;</p>
-
-<p style="text-align: center; margin: 0; padding: 0;"><kbd>Last updated: December 2025</kbd></p>

--- a/git-integration-for-jira-cloud/Signals-general-view-gij-cloud.md
+++ b/git-integration-for-jira-cloud/Signals-general-view-gij-cloud.md
@@ -1,11 +1,22 @@
 ---
-
-title: General View (Signals)
-description: Learn how to use the General View in Signals to monitor Jira issues, track activity timelines, and filter by projects, sprints, and team members.
+title: "General View (Signals)"
+description: "Learn how to use the General View in Signals to monitor Jira issues, track activity timelines, and filter by projects, sprints, and team members."
+product: "Git Integration for Jira Cloud"
+feature: "General View (Signals)"
+content_type: "concept"
+audience: "developer"
+plan_required: "Advanced"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "User"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "concept", "developer", "Advanced"]
 taxonomy:
     category: git-integration-for-jira-cloud
-
 ---
+<kbd>Last updated: March 2026</kbd>
 
 ![](/wp-content/uploads/tij-gitcloud-general-view-tab-access.png)
 
@@ -170,5 +181,3 @@ To apply your filter selections and display results, click **Search**.
 [Pull request timeline reindex](/git-integration-for-jira-cloud/pull-request-timeline-for-Signals-gij-cloud)
 
 <p>&nbsp;</p>
-
-<p style="text-align: center; margin: 0; padding: 0;"><kbd>Last updated: December 2025</kbd></p>

--- a/git-integration-for-jira-cloud/Signals-gij-cloud.md
+++ b/git-integration-for-jira-cloud/Signals-gij-cloud.md
@@ -1,11 +1,22 @@
 ---
-
-title: Signals - GIJ Advanced
-description: Learn how to use Signals (Team Insights for Jira) to monitor team activity, track sprint progress, and identify work risks in Git Integration for Jira Cloud.
+title: "Signals - GIJ Advanced"
+description: "Learn how to use Signals (Team Insights for Jira) to monitor team activity, track sprint progress, and identify work risks in Git Integration for Jira Cloud."
+product: "Git Integration for Jira Cloud"
+feature: "Signals - GIJ Advanced"
+content_type: "install"
+audience: "admin"
+plan_required: "Advanced"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "Jira Administrator"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "install", "admin", "Advanced"]
 taxonomy:
     category: git-integration-for-jira-cloud
-
 ---
+<kbd>Last updated: March 2026</kbd>
 
 <div class='embed-container embed-container--16-9'>
     <iframe width='709' height='382' src='https://www.youtube.com/embed/ctzCdY9CXOg' frameborder='0' allowfullscreen ></iframe>
@@ -195,5 +206,3 @@ Signals shows Jira activity for all users. When you install [Git Integration for
 [Pull request timeline reindex](/git-integration-for-jira-cloud/pull-request-timeline-for-Signals-gij-cloud/)
 
 <p>&nbsp;</p>
-
-<p style="text-align: center; margin: 0; padding: 0;"><kbd>Last updated: December 2025</kbd></p>

--- a/git-integration-for-jira-cloud/Signals-known-issues-gij-cloud.md
+++ b/git-integration-for-jira-cloud/Signals-known-issues-gij-cloud.md
@@ -1,11 +1,22 @@
 ---
-
-title: Known Issues for Signals
-description: Review known issues and workarounds for the Signals feature in Git Integration for Jira Cloud.
+title: "Known Issues for Signals"
+description: "Review known issues and workarounds for the Signals feature in Git Integration for Jira Cloud."
+product: "Git Integration for Jira Cloud"
+feature: "Known Issues for Signals"
+content_type: "troubleshooting"
+audience: "all"
+plan_required: "Advanced"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "all"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "troubleshooting", "Advanced"]
 taxonomy:
     category: git-integration-for-jira-cloud
-
 ---
+<kbd>Last updated: March 2026</kbd>
 
 Signals provides features for team leaders and project leads. This page documents known issues and their workarounds.
 
@@ -52,5 +63,3 @@ Invalid issue key searches produce an error message:
 [Pull request timeline reindex](/git-integration-for-jira-cloud/pull-request-timeline-for-Signals-gij-cloud)
 
 <p>&nbsp;</p>
-
-<p style="text-align: center; margin: 0; padding: 0;"><kbd>Last updated: December 2025</kbd></p>

--- a/git-integration-for-jira-cloud/Signals-risk-view-gij-cloud.md
+++ b/git-integration-for-jira-cloud/Signals-risk-view-gij-cloud.md
@@ -1,11 +1,22 @@
 ---
-
-title: Signals Risk View Settings
-description: Configure risk thresholds and severity levels for sprints, issues, and pull requests in Signals to identify potential project risks.
+title: "Signals Risk View Settings"
+description: "Configure risk thresholds and severity levels for sprints, issues, and pull requests in Signals to identify potential project risks."
+product: "Git Integration for Jira Cloud"
+feature: "Signals Risk View Settings"
+content_type: "concept"
+audience: "developer"
+plan_required: "Advanced"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "User"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "concept", "developer", "Advanced"]
 taxonomy:
     category: git-integration-for-jira-cloud
-
 ---
+<kbd>Last updated: March 2026</kbd>
 
 Signals highlights sprints or issues not progressing as expected, drawing attention to potential delays. Managers can activate or deactivate risk alerts based on project requirements. Each risk has a configurable severity level that indicates its impact on the project.
 
@@ -144,5 +155,3 @@ Use this setting to identify code reviews that need attention or may be blocking
 [Pull request timeline reindex](/git-integration-for-jira-cloud/pull-request-timeline-for-Signals-gij-cloud)
 
 <p>&nbsp;</p>
-
-<p style="text-align: center; margin: 0; padding: 0;"><kbd>Last updated: December 2025</kbd></p>

--- a/git-integration-for-jira-cloud/Signals-teams-view-gij-cloud.md
+++ b/git-integration-for-jira-cloud/Signals-teams-view-gij-cloud.md
@@ -1,11 +1,22 @@
 ---
-
-title: Signals Teams View
-description: Learn how to use the Teams View in Signals to monitor team member activities, track assignments, and view individual progress.
+title: "Signals Teams View"
+description: "Learn how to use the Teams View in Signals to monitor team member activities, track assignments, and view individual progress."
+product: "Git Integration for Jira Cloud"
+feature: "Signals Teams View"
+content_type: "concept"
+audience: "all"
+plan_required: "Advanced"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "all"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "concept", "Advanced"]
 taxonomy:
     category: git-integration-for-jira-cloud
-
 ---
+<kbd>Last updated: March 2026</kbd>
 
 ![](/wp-content/uploads/tij-gitcloud-teams-view-main-screen.png)
 
@@ -168,5 +179,3 @@ To apply your filter selections and display results, click **Search**.
 [Pull request timeline reindex](/git-integration-for-jira-cloud/pull-request-timeline-for-Signals-gij-cloud)
 
 <p>&nbsp;</p>
-
-<p style="text-align: center; margin: 0; padding: 0;"><kbd>Last updated: December 2025</kbd></p>

--- a/git-integration-for-jira-cloud/Testing.md
+++ b/git-integration-for-jira-cloud/Testing.md
@@ -1,12 +1,22 @@
 ---
-
-title: Format Testing Page
-description:
+title: "Format Testing Page"
+description: "Step-by-step guide to Format Testing Page in Git Integration for Jira Cloud, for Jira Cloud users."
+product: "Git Integration for Jira Cloud"
+feature: "Format Testing Page"
+content_type: "integration"
+audience: "all"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "all"
+version_required: "all"
+status: "draft"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "integration", "draft"]
 taxonomy:
     category: git-integration-for-jira-cloud
-
 ---
-
+<kbd>Last updated: March 2026</kbd>
 
 <b style='background-color:#FFFCC3; padding:1px 5px; color:#181D28; border-radius:3px; margin: 0 5px; font-size: small;'>NEXT</b> [Integration Creation and Post Integration Config](https://help.gitkraken.com/git-integration-for-jira-cloud/Getting-Started-Guide-Integration-Creation-Post-Integration-Config)
 
@@ -18,4 +28,3 @@ taxonomy:
 [<b style='background-color:#F1F1F1; padding:1px 5px; color:#181D28; border-radius:3px; margin: 0 5px; font-size: small;'>NEXT</b>](https://help.gitkraken.com/git-integration-for-jira-cloud/Getting-Started-Guide-Integration-Creation-Post-Integration-Config) <a href="https://help.gitkraken.com/git-integration-for-jira-cloud/Getting-Started-Guide-Integration-Creation-Post-Integration-Config">**Integration Creation and Post Integration Configuration**</a>
 
 [<b style='background-color:#F1F1F1; padding:1px 5px; color:#181D28; border-radius:3px; margin: 0 5px; font-size: small;'>PREVIOUS</b>](https://help.gitkraken.com/git-integration-for-jira-cloud/Getting-Started-Guide/) <a href="https://help.gitkraken.com/git-integration-for-jira-cloud/Getting-Started-Guide/">Getting Started</a>
-

--- a/git-integration-for-jira-cloud/adding-webhooks-for-azure-devops-repos-vsts-gij-cloud.md
+++ b/git-integration-for-jira-cloud/adding-webhooks-for-azure-devops-repos-vsts-gij-cloud.md
@@ -1,9 +1,22 @@
 ---
-title: Adding webhooks for Azure DevOps Repos | VSTS
-description: Configure webhooks for Azure DevOps Repos (VSTS) in Git Integration for Jira Cloud.
+title: "Adding webhooks for Azure DevOps Repos | VSTS"
+description: "Configure webhooks for Azure DevOps Repos (VSTS) in Git Integration for Jira Cloud."
+product: "Git Integration for Jira Cloud"
+feature: "Adding webhooks for Azure DevOps Repos | VSTS"
+content_type: "reference"
+audience: "admin"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: ["Azure DevOps"]
+role_required: "Jira Administrator"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "reference", "admin", "Azure DevOps"]
 taxonomy:
     category: git-integration-for-jira-cloud
 ---
+<kbd>Last updated: March 2026</kbd>
 
 <div class="bbb-callout bbb--info">
     <div class="irow">
@@ -111,5 +124,3 @@ Create separate service hooks for each pull request event:
 Repeat steps 3-9 for each event type, changing only the trigger event in step 5a.
 
 ![](/wp-content/uploads/gij-cloud-TFS-webhook-service-hook-list-c.png)
-
-<kbd>Last updated: December 2025</kbd>

--- a/git-integration-for-jira-cloud/adding-webhooks-for-azure-devops-server-tfs-gij-cloud.md
+++ b/git-integration-for-jira-cloud/adding-webhooks-for-azure-devops-server-tfs-gij-cloud.md
@@ -1,9 +1,22 @@
 ---
-title: Adding webhooks for Azure DevOps Server | TFS
-description: Configure webhooks for Azure DevOps Server (TFS) in Git Integration for Jira Cloud.
+title: "Adding webhooks for Azure DevOps Server | TFS"
+description: "Configure webhooks for Azure DevOps Server (TFS) in Git Integration for Jira Cloud."
+product: "Git Integration for Jira Cloud"
+feature: "Adding webhooks for Azure DevOps Server | TFS"
+content_type: "reference"
+audience: "admin"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: ["Azure DevOps Server"]
+role_required: "Jira Administrator"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "reference", "admin", "Azure DevOps Server"]
 taxonomy:
     category: git-integration-for-jira-cloud
 ---
+<kbd>Last updated: March 2026</kbd>
 
 <div class="bbb-callout bbb--info">
     <div class="irow">
@@ -111,5 +124,3 @@ Create separate service hooks for each pull request event:
 Repeat steps 3-9 for each event type, changing only the trigger event in step 5a.
 
 ![](/wp-content/uploads/gij-cloud-TFS-webhook-service-hook-list-c.png)
-
-<kbd>Last updated: December 2025</kbd>

--- a/git-integration-for-jira-cloud/adding-webhooks-for-bitbucket-cloud-gij-cloud.md
+++ b/git-integration-for-jira-cloud/adding-webhooks-for-bitbucket-cloud-gij-cloud.md
@@ -1,9 +1,22 @@
 ---
-title: Adding webhooks for Bitbucket Cloud
-description: Configure webhooks for Bitbucket Cloud repositories in Git Integration for Jira Cloud.
+title: "Adding webhooks for Bitbucket Cloud"
+description: "Configure webhooks for Bitbucket Cloud repositories in Git Integration for Jira Cloud."
+product: "Git Integration for Jira Cloud"
+feature: "Adding webhooks for Bitbucket Cloud"
+content_type: "reference"
+audience: "developer"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: ["Bitbucket Cloud"]
+role_required: "User"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "reference", "developer", "Bitbucket Cloud"]
 taxonomy:
     category: git-integration-for-jira-cloud
 ---
+<kbd>Last updated: March 2026</kbd>
 
 <div class="bbb-callout bbb--info">
     <div class="irow">
@@ -76,5 +89,3 @@ For pull request events, configure three separate triggers:
 3. Pull Request - **Updated**
 
 ![](/wp-content/uploads/gij-webhooks-bitbucket-sample.png)
-
-<kbd>Last updated: December 2025</kbd>

--- a/git-integration-for-jira-cloud/adding-webhooks-for-gerrit-gij-cloud.md
+++ b/git-integration-for-jira-cloud/adding-webhooks-for-gerrit-gij-cloud.md
@@ -1,9 +1,22 @@
 ---
-title: Adding webhooks for Gerrit
-description: Configure webhooks for Gerrit repositories in Git Integration for Jira Cloud.
+title: "Adding webhooks for Gerrit"
+description: "Configure webhooks for Gerrit repositories in Git Integration for Jira Cloud."
+product: "Git Integration for Jira Cloud"
+feature: "Adding webhooks for Gerrit"
+content_type: "install"
+audience: "admin"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: ["Gerrit"]
+role_required: "Jira Administrator"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "install", "admin", "Gerrit"]
 taxonomy:
     category: git-integration-for-jira-cloud
 ---
+<kbd>Last updated: March 2026</kbd>
 
 Webhooks are not built into Gerrit by default. You must install and configure the Gerrit webhook plugin before using webhooks with Git Integration for Jira Cloud.
 
@@ -98,5 +111,3 @@ Create a `payload.json` file:
 ```
 
 Replace `repository-origin` with your repository's origin URL.
-
-<kbd>Last updated: December 2025</kbd>

--- a/git-integration-for-jira-cloud/adding-webhooks-for-github-repository-gij-cloud.md
+++ b/git-integration-for-jira-cloud/adding-webhooks-for-github-repository-gij-cloud.md
@@ -1,9 +1,22 @@
 ---
-title: Adding webhooks for GitHub repository
-description: Configure webhooks for GitHub repositories in Git Integration for Jira Cloud.
+title: "Adding webhooks for GitHub repository"
+description: "Configure webhooks for GitHub repositories in Git Integration for Jira Cloud."
+product: "Git Integration for Jira Cloud"
+feature: "Adding webhooks for GitHub repository"
+content_type: "reference"
+audience: "developer"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: ["GitHub"]
+role_required: "User"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "reference", "developer", "GitHub"]
 taxonomy:
     category: git-integration-for-jira-cloud
 ---
+<kbd>Last updated: March 2026</kbd>
 
 <div class="bbb-callout bbb--info">
     <div class="irow">
@@ -116,5 +129,3 @@ Indexing triggers are automatically registered for each GitHub repository connec
     </div>
     </div>
 </div>
-
-<kbd>Last updated: December 2025</kbd>

--- a/git-integration-for-jira-cloud/adding-webhooks-for-gitlab-repository-gij-cloud.md
+++ b/git-integration-for-jira-cloud/adding-webhooks-for-gitlab-repository-gij-cloud.md
@@ -1,9 +1,22 @@
 ---
-title: Adding webhooks for GitLab repository
-description: Configure webhooks for GitLab repositories in Git Integration for Jira Cloud.
+title: "Adding webhooks for GitLab repository"
+description: "Configure webhooks for GitLab repositories in Git Integration for Jira Cloud."
+product: "Git Integration for Jira Cloud"
+feature: "Adding webhooks for GitLab repository"
+content_type: "reference"
+audience: "admin"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: ["GitLab"]
+role_required: "Jira Administrator"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "reference", "admin", "GitLab"]
 taxonomy:
     category: git-integration-for-jira-cloud
 ---
+<kbd>Last updated: March 2026</kbd>
 
 <div class="bbb-callout bbb--tip">
     <div class="irow">
@@ -81,5 +94,3 @@ To receive both push and merge request events:
     ![](/wp-content/uploads/gij-gitlab-merge-request-event-trigger-webhook.png)
 
 4. Click **Add webhook** or **Save changes**.
-
-<kbd>Last updated: December 2025</kbd>

--- a/git-integration-for-jira-cloud/adding-webhooks-to-aws-codecommit-gij-cloud.md
+++ b/git-integration-for-jira-cloud/adding-webhooks-to-aws-codecommit-gij-cloud.md
@@ -1,9 +1,22 @@
 ---
-title: Adding webhooks to AWS CodeCommit
-description: Configure webhooks for AWS CodeCommit repositories in Git Integration for Jira Cloud.
+title: "Adding webhooks to AWS CodeCommit"
+description: "Configure webhooks for AWS CodeCommit repositories in Git Integration for Jira Cloud."
+product: "Git Integration for Jira Cloud"
+feature: "Adding webhooks to AWS CodeCommit"
+content_type: "reference"
+audience: "admin"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: ["AWS CodeCommit"]
+role_required: "Jira Administrator"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "reference", "admin", "AWS CodeCommit"]
 taxonomy:
     category: git-integration-for-jira-cloud
 ---
+<kbd>Last updated: March 2026</kbd>
 
 <div class="bbb-callout bbb--info">
     <div class="irow">
@@ -168,5 +181,3 @@ If errors appear, verify your AWS trigger settings and reindex the integration.
     </div>
     </div>
 </div>
-
-<kbd>Last updated: December 2025</kbd>

--- a/git-integration-for-jira-cloud/administration-gij-cloud.md
+++ b/git-integration-for-jira-cloud/administration-gij-cloud.md
@@ -1,9 +1,22 @@
 ---
-title: Administration
-description: Administration resources for Git Integration for Jira Cloud including manager permissions, trusted users, and general settings.
+title: "Administration"
+description: "Administration resources for Git Integration for Jira Cloud including manager permissions, trusted users, and general settings."
+product: "Git Integration for Jira Cloud"
+feature: "Administration"
+content_type: "security"
+audience: "admin"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "Jira Administrator"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "security", "admin"]
 taxonomy:
     category: git-integration-for-jira-cloud
 ---
+<kbd>Last updated: March 2026</kbd>
 
 This section contains administration resources for configuring and managing Git Integration for Jira Cloud.
 
@@ -24,5 +37,3 @@ Adjust performance and feature settings for Git Integration for Jira Cloud throu
 ### [Set Up GitLab Server for API Calls](/git-integration-for-jira-cloud/setup-gitlab-server-to-respond-to-incoming-network-api-calls-gij-cloud)
 
 Configure your GitLab server to respond to incoming network API calls and provide correct repository clone links to users.
-
-<kbd>Last updated: December 2025</kbd>

--- a/git-integration-for-jira-cloud/allow-list-whitelist-bigbrassband-cloud-gij-cloud.md
+++ b/git-integration-for-jira-cloud/allow-list-whitelist-bigbrassband-cloud-gij-cloud.md
@@ -1,9 +1,22 @@
 ---
-title: Allow list (whitelist) GIJ Cloud
-description: Configure firewall settings to allow Git Integration for Jira Cloud to access your self-hosted git repositories.
+title: "Allow list (whitelist) GIJ Cloud"
+description: "Configure firewall settings to allow Git Integration for Jira Cloud to access your self-hosted git repositories."
+product: "Git Integration for Jira Cloud"
+feature: "Allow list (whitelist) GIJ Cloud"
+content_type: "integration"
+audience: "all"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "all"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "integration"]
 taxonomy:
     category: git-integration-for-jira-cloud
 ---
+<kbd>Last updated: March 2026</kbd>
 
 <div class="bbb-callout bbb--info">
     <div class="irow">
@@ -216,5 +229,3 @@ For more information, see:
 ## Get Support
 
 Contact [GIJ Cloud Support](https://help.gitkraken.com/git-integration-for-jira-cloud/gij-cloud-contact-support/) for help connecting self-hosted git servers or repositories.
-
-<kbd>Last updated: December 2025</kbd>

--- a/git-integration-for-jira-cloud/app-support-gij-cloud.md
+++ b/git-integration-for-jira-cloud/app-support-gij-cloud.md
@@ -1,9 +1,22 @@
 ---
-title: App Support
-description: Get help with Git Integration for Jira Cloud including installation, migration, and troubleshooting.
+title: "App Support"
+description: "Get help with Git Integration for Jira Cloud including installation, migration, and troubleshooting."
+product: "Git Integration for Jira Cloud"
+feature: "App Support"
+content_type: "troubleshooting"
+audience: "admin"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "Jira Administrator"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "troubleshooting", "admin"]
 taxonomy:
     category: git-integration-for-jira-cloud
 ---
+<kbd>Last updated: March 2026</kbd>
 
 We are committed to providing efficient and reliable support. This page contains helpful tips to get started.
 
@@ -108,5 +121,3 @@ With the release of the Edge browser in 2015, IE has not received major updates.
     </div>
     </div>
 </div>
-
-<kbd>Last updated: December 2025</kbd>

--- a/git-integration-for-jira-cloud/associating-project-permissions-gij-cloud.md
+++ b/git-integration-for-jira-cloud/associating-project-permissions-gij-cloud.md
@@ -1,11 +1,22 @@
 ---
-
-title: Associating project permissions
-description: How to configure project-level permissions for Git integrations and repositories
+title: "Associating project permissions"
+description: "How to configure project-level permissions for Git integrations and repositories"
+product: "Git Integration for Jira Cloud"
+feature: "Associating project permissions"
+content_type: "integration"
+audience: "developer"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "User"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "integration", "developer"]
 taxonomy:
     category: git-integration-for-jira-cloud
-
 ---
+<kbd>Last updated: March 2026</kbd>
 
 Integrations and repositories can be associated with one or more Jira projects to restrict which users can view development information. All newly-connected repositories or integrations are associated with all Jira projects by default.
 
@@ -177,5 +188,3 @@ Watch the video below to learn about different settings for each project permiss
 **Associating project permissions** (this page)
 
 <p>&nbsp;</p>
-
-<p style="text-align: center; margin: 0; padding: 0;"><kbd>Last updated: December 2025</kbd></p>

--- a/git-integration-for-jira-cloud/automatically-connect-to-https-git-repositories-with-self-signed-ssl-certificates-or-other-ssl-issues-gij-cloud.md
+++ b/git-integration-for-jira-cloud/automatically-connect-to-https-git-repositories-with-self-signed-ssl-certificates-or-other-ssl-issues-gij-cloud.md
@@ -1,11 +1,22 @@
 ---
-
-title: Automatically connect to HTTPS git repositories with self-signed SSL certificates or other SSL issues
-description: How to set up integrations with self-signed SSL certificates using automatic connection
+title: "Automatically connect to HTTPS git repositories with self-signed SSL certificates or other SSL issues"
+description: "How to set up integrations with self-signed SSL certificates using automatic connection"
+product: "Git Integration for Jira Cloud"
+feature: "Automatically connect to HTTPS git repositories with self-signed SSL certificates or other SSL issues"
+content_type: "security"
+audience: "admin"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "Jira Administrator"
+version_required: "all"
+status: "deprecated"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "security", "admin", "deprecated"]
 taxonomy:
     category: git-integration-for-jira-cloud
-
 ---
+<kbd>Last updated: March 2026</kbd>
 
 <b style='background-color:#EAE5FE; padding:1px 5px; color:#412C92; border-radius:3px; margin: 0 5px; font-size: small;'>GITHUB ENTERPRISE</b> <b style='background-color:#FFE3B2; padding:1px 5px; color:#A35F00; border-radius:3px; margin: 0 5px; font-size: small;'>GITLAB CE/EE</b>
 
@@ -44,5 +55,3 @@ This integration appears in the Manage integrations list. Go to ![](/wp-content/
 [**Next:** Manually connect to HTTPS git repositories with self-signed SSL certificates or other SSL issues](/git-integration-for-jira-cloud/manually-connect-to-https-git-repositories-with-self-signed-ssl-certificates-or-other-ssl-issues-gij-cloud)
 
 <p>&nbsp;</p>
-
-<p style="text-align: center; margin: 0; padding: 0;"><kbd>Last updated: December 2025</kbd></p>

--- a/git-integration-for-jira-cloud/aws-codecommit-gij-cloud.md
+++ b/git-integration-for-jira-cloud/aws-codecommit-gij-cloud.md
@@ -1,11 +1,22 @@
 ---
-
-title: AWS CodeCommit for Git Integration for Jira Cloud
-description: Learn how to integrate AWS CodeCommit git repositories with Jira Cloud using Git Integration for Jira.
+title: "AWS CodeCommit for Git Integration for Jira Cloud"
+description: "Learn how to integrate AWS CodeCommit git repositories with Jira Cloud using Git Integration for Jira."
+product: "Git Integration for Jira Cloud"
+feature: "AWS CodeCommit for Git Integration for Jira Cloud"
+content_type: "concept"
+audience: "developer"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: ["AWS CodeCommit"]
+role_required: "User"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "concept", "developer", "AWS CodeCommit"]
 taxonomy:
     category: git-integration-for-jira-cloud
-
 ---
+<kbd>Last updated: March 2026</kbd>
 
 <div class="bbb-callout bbb--info">
     <div class="irow">
@@ -513,6 +524,3 @@ The branch and the pull request status are also displayed on the developer panel
 [Introduction to Git integration](/git-integration-for-jira-cloud/integration-guide-gij-cloud) (Git Integration for Jira Cloud)
 
 <br>
-
-<kbd>Last updated: December 2025</kbd>
-

--- a/git-integration-for-jira-cloud/aws-codecommit-webhook-events-gij-cloud.md
+++ b/git-integration-for-jira-cloud/aws-codecommit-webhook-events-gij-cloud.md
@@ -1,9 +1,22 @@
 ---
-title: AWS CodeCommit webhook events
-description: Reference documentation for AWS CodeCommit webhook event types supported by Git Integration for Jira Cloud.
+title: "AWS CodeCommit webhook events"
+description: "Reference documentation for AWS CodeCommit webhook event types supported by Git Integration for Jira Cloud."
+product: "Git Integration for Jira Cloud"
+feature: "AWS CodeCommit webhook events"
+content_type: "reference"
+audience: "all"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: ["AWS CodeCommit"]
+role_required: "all"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "reference", "AWS CodeCommit"]
 taxonomy:
     category: git-integration-for-jira-cloud
 ---
+<kbd>Last updated: March 2026</kbd>
 
 This page documents the AWS CodeCommit webhook event types that Git Integration for Jira Cloud supports.
 
@@ -65,5 +78,3 @@ This page documents the AWS CodeCommit webhook event types that Git Integration 
 - [GitLab webhook events](/git-integration-for-jira-cloud/gitlab-webhook-events-gij-cloud)
 - [Microsoft webhook events](/git-integration-for-jira-cloud/microsoft-webhook-events-gij-cloud)
 - [Bitbucket webhook events](/git-integration-for-jira-cloud/bitbucket-webhook-events-gij-cloud)
-
-<kbd>Last updated: December 2025</kbd>

--- a/git-integration-for-jira-cloud/azure-devops-server-team-foundation-services-tfs-gij-cloud.md
+++ b/git-integration-for-jira-cloud/azure-devops-server-team-foundation-services-tfs-gij-cloud.md
@@ -1,11 +1,22 @@
 ---
-
-title: Azure DevOps Server | Team Foundation Services (TFS)
-description: Learn how to integrate Azure DevOps Server and Team Foundation Services (TFS) git repositories with Jira Cloud using Git Integration for Jira.
+title: "Azure DevOps Server | Team Foundation Services (TFS)"
+description: "Learn how to integrate Azure DevOps Server and Team Foundation Services (TFS) git repositories with Jira Cloud using Git Integration for Jira."
+product: "Git Integration for Jira Cloud"
+feature: "Azure DevOps Server | Team Foundation Services (TFS)"
+content_type: "integration"
+audience: "admin"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: ["Azure DevOps Server"]
+role_required: "Jira Administrator"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "integration", "admin", "Azure DevOps Server"]
 taxonomy:
     category: git-integration-for-jira-cloud
-
 ---
+<kbd>Last updated: March 2026</kbd>
 
 <div class="bbb-callout bbb--info">
     <div class="irow">
@@ -465,6 +476,3 @@ Once approved, the team leader or reviewer can then complete the merge. The com
 [Introduction to Git integration](/git-integration-for-jira-cloud/integration-guide-gij-cloud) (Git Integration for Jira Cloud)
 
 <br>
-
-<kbd>Last updated: December 2025</kbd>
-

--- a/git-integration-for-jira-cloud/azure-devops-visual-studio-team-services-vsts-gij-cloud.md
+++ b/git-integration-for-jira-cloud/azure-devops-visual-studio-team-services-vsts-gij-cloud.md
@@ -1,11 +1,22 @@
 ---
-
-title: Azure DevOps | Visual Studio Team Services (VSTS)
-description: Learn how to integrate Azure DevOps and Visual Studio Team Services (VSTS) git repositories with Jira Cloud using Git Integration for Jira.
+title: "Azure DevOps | Visual Studio Team Services (VSTS)"
+description: "Learn how to integrate Azure DevOps and Visual Studio Team Services (VSTS) git repositories with Jira Cloud using Git Integration for Jira."
+product: "Git Integration for Jira Cloud"
+feature: "Azure DevOps | Visual Studio Team Services (VSTS)"
+content_type: "integration"
+audience: "admin"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: ["Azure DevOps"]
+role_required: "Jira Administrator"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "integration", "admin", "Azure DevOps"]
 taxonomy:
     category: git-integration-for-jira-cloud
-
 ---
+<kbd>Last updated: March 2026</kbd>
 
 <div class="bbb-callout bbb--info">
     <div class="irow">
@@ -566,6 +577,3 @@ Not by itself, you need both [Git Integration for Jira Cloud app](https://market
 [Introduction to Git integration](/git-integration-for-jira-cloud/integration-guide-gij-cloud) (Git Integration for Jira Cloud)
 
 <br>
-
-<kbd>Last updated: December 2025</kbd>
-

--- a/git-integration-for-jira-cloud/bigbrassband-acquisition-info-faqs-gij-cloud.md
+++ b/git-integration-for-jira-cloud/bigbrassband-acquisition-info-faqs-gij-cloud.md
@@ -1,11 +1,22 @@
 ---
-
-title: BigBrassBand Acquisition Info & FAQs
-description: Information and frequently asked questions about GitKraken's acquisition of BigBrassBand and Git Integration for Jira
+title: "BigBrassBand Acquisition Info & FAQs"
+description: "Information and frequently asked questions about GitKraken's acquisition of BigBrassBand and Git Integration for Jira"
+product: "Git Integration for Jira Cloud"
+feature: "BigBrassBand Acquisition Info & FAQs"
+content_type: "faq"
+audience: "all"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "all"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "faq"]
 taxonomy:
     category: git-integration-for-jira-cloud
-
 ---
+<kbd>Last updated: March 2026</kbd>
 
 BigBrassBand has been acquired by [GitKraken](https://www.gitkraken.com), maker of Git collaboration tools for development teams. GitKraken is the world's most popular graphical user interface for Git, helping over 2.5 million developers in 75,000 companies worldwide develop code faster by making Git easier, safer, and more powerful. This acquisition brings together over 6 million Git users worldwide and represents an exciting move for developers and DevOps teams centered around Git.
 
@@ -52,5 +63,3 @@ Additionally, we're interested in talking with Solutions Partners who are intere
 Questions? Contact us at [support@gitkraken.com](mailto:support@gitkraken.com).
 
 <p>&nbsp;</p>
-
-<p style="text-align: center; margin: 0; padding: 0;"><kbd>Last updated: December 2025</kbd></p>

--- a/git-integration-for-jira-cloud/bitbucket-cloud-gij-cloud.md
+++ b/git-integration-for-jira-cloud/bitbucket-cloud-gij-cloud.md
@@ -1,11 +1,22 @@
 ---
-
-title: Bitbucket Cloud
-description: Learn how to integrate Bitbucket Cloud git repositories with Jira Cloud using Git Integration for Jira.
+title: "Bitbucket Cloud"
+description: "Learn how to integrate Bitbucket Cloud git repositories with Jira Cloud using Git Integration for Jira."
+product: "Git Integration for Jira Cloud"
+feature: "Bitbucket Cloud"
+content_type: "integration"
+audience: "admin"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: ["Bitbucket Cloud"]
+role_required: "Jira Administrator"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "integration", "admin", "Bitbucket Cloud"]
 taxonomy:
     category: git-integration-for-jira-cloud
-
 ---
+<kbd>Last updated: March 2026</kbd>
 
 <div class="bbb-callout bbb--tip">
     <div class="irow">
@@ -296,6 +307,3 @@ Access the **Create branch** and **Create pull/merge request** features in t
 [Introduction to Git integration](/git-integration-for-jira-cloud/integration-guide-gij-cloud) (Git Integration for Jira Cloud)
 
 <br>
-
-<kbd>Last updated: December 2025</kbd>
-

--- a/git-integration-for-jira-cloud/bitbucket-jmespath-filter-examples-gij-cloud.md
+++ b/git-integration-for-jira-cloud/bitbucket-jmespath-filter-examples-gij-cloud.md
@@ -1,11 +1,22 @@
 ---
-
-title: Bitbucket JMESPath filter examples
-description:
+title: "Bitbucket JMESPath filter examples"
+description: "Step-by-step guide to Bitbucket JMESPath filter examples in Git Integration for Jira Cloud for Bitbucket, for Jira Cloud users."
+product: "Git Integration for Jira Cloud"
+feature: "Bitbucket JMESPath filter examples"
+content_type: "integration"
+audience: "all"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: ["Bitbucket"]
+role_required: "all"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "integration", "Bitbucket"]
 taxonomy:
     category: git-integration-for-jira-cloud
-
 ---
+<kbd>Last updated: March 2026</kbd>
 
 &nbsp;
 
@@ -66,4 +77,3 @@ Lists repositories with names `'repo1name'` and `'repo2name'`.
 *   [Microsoft | VSTS | TFS | Azure Repos JMESPath filter examples](/git-integration-for-jira-cloud/microsoft-vsts-tfs-azure-repos-jmespath-filter-examples-gij-cloud)
 
 *   **Bitbucket JMESPath filter examples** (this page)
-

--- a/git-integration-for-jira-cloud/bitbucket-webhook-events-gij-cloud.md
+++ b/git-integration-for-jira-cloud/bitbucket-webhook-events-gij-cloud.md
@@ -1,9 +1,22 @@
 ---
-title: Bitbucket webhook events
-description: Reference documentation for Bitbucket webhook event types supported by Git Integration for Jira Cloud.
+title: "Bitbucket webhook events"
+description: "Reference documentation for Bitbucket webhook event types supported by Git Integration for Jira Cloud."
+product: "Git Integration for Jira Cloud"
+feature: "Bitbucket webhook events"
+content_type: "reference"
+audience: "developer"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: ["Bitbucket"]
+role_required: "User"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "reference", "developer", "Bitbucket"]
 taxonomy:
     category: git-integration-for-jira-cloud
 ---
+<kbd>Last updated: March 2026</kbd>
 
 This page documents the Bitbucket webhook event types that Git Integration for Jira Cloud supports.
 
@@ -112,5 +125,3 @@ This page documents the Bitbucket webhook event types that Git Integration for J
 - [GitLab webhook events](/git-integration-for-jira-cloud/gitlab-webhook-events-gij-cloud)
 - [AWS CodeCommit webhook events](/git-integration-for-jira-cloud/aws-codecommit-webhook-events-gij-cloud)
 - [Microsoft webhook events](/git-integration-for-jira-cloud/microsoft-webhook-events-gij-cloud)
-
-<kbd>Last updated: December 2025</kbd>

--- a/git-integration-for-jira-cloud/cicd-getting-started-with-ci-cd-for-jira-gij-cloud.md
+++ b/git-integration-for-jira-cloud/cicd-getting-started-with-ci-cd-for-jira-gij-cloud.md
@@ -1,11 +1,22 @@
 ---
-
-title: CI/CD for Jira Cloud
-description: Learn how to use CI/CD for Jira Cloud to connect your DevOps pipelines with Jira's builds and deployments features.
+title: "CI/CD for Jira Cloud"
+description: "Learn how to use CI/CD for Jira Cloud to connect your DevOps pipelines with Jira's builds and deployments features."
+product: "Git Integration for Jira Cloud"
+feature: "CI/CD for Jira Cloud"
+content_type: "concept"
+audience: "admin"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "Jira Administrator"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "concept", "admin"]
 taxonomy:
     category: git-integration-for-jira-cloud
-
 ---
+<kbd>Last updated: March 2026</kbd>
 
 CI/CD for Jira (previously a free extension, now included in Git Integration for Jira) connects your CI/CD DevOps pipelines with Jira's builds and deployments features. Just as Git Integration for Jira exposes commits, branches, and pull requests, CI/CD for Jira adds build and deployment information associated with Jira issues.
 
@@ -194,5 +205,3 @@ Git Integration for Jira supports triggers for branches, commits, and pull reque
 <img src='/wp-content/uploads/gij-cloud-cicd-a4j-1.png' height=574 width=562 style='margin: 15px auto 25px auto; max-width: 100%' />
 
 To create new rules, go to Project settings ➜ Automation ➜ **Create Rule**. For more information on setting up Automation for Jira rules, visit the [Git Integration + Jira Automation](/git-integration-for-jira-cloud/git-integration-jira-automation-gij-cloud/) article.
-
-<kbd>Last updated: December 2025</kbd>

--- a/git-integration-for-jira-cloud/classic-indexing-explainer-gij-cloud.md
+++ b/git-integration-for-jira-cloud/classic-indexing-explainer-gij-cloud.md
@@ -1,11 +1,22 @@
 ---
-
-title: Classic Indexing Explainer
-description: Learn how Git Integration for Jira Cloud indexes commits, branches, tags, and pull requests using classic indexing.
+title: "Classic Indexing Explainer"
+description: "Learn how Git Integration for Jira Cloud indexes commits, branches, tags, and pull requests using classic indexing."
+product: "Git Integration for Jira Cloud"
+feature: "Classic Indexing Explainer"
+content_type: "concept"
+audience: "admin"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "Jira Administrator"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "concept", "admin"]
 taxonomy:
     category: git-integration-for-jira-cloud
-
 ---
+<kbd>Last updated: March 2026</kbd>
 
 **What's on this page:**
 - [How is git data indexed?](#how-is-git-data-indexed)
@@ -225,5 +236,3 @@ You can update integrations manually via the Manage git repositories screen by o
 ## Branch and pull/merge request name index triggers
 
 Pull/merge requests are still indexed based on branch name even if the PR/MR title does not have the Jira issue key – as long as the branch name contains the Jira issue key.
-
-<kbd>Last updated: December 2025</kbd>

--- a/git-integration-for-jira-cloud/code-syntax-highlighter-gij-cloud.md
+++ b/git-integration-for-jira-cloud/code-syntax-highlighter-gij-cloud.md
@@ -1,11 +1,23 @@
 ---
-
-title: Code syntax highlighter
-description:
+title: "Code syntax highlighter"
+description: "Step-by-step guide to Code syntax highlighter in Git Integration for Jira Cloud, for Jira Cloud users."
+product: "Git Integration for Jira Cloud"
+feature: "Code syntax highlighter"
+content_type: "integration"
+audience: "all"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "all"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "integration"]
 taxonomy:
     category: git-integration-for-jira-cloud
-
 ---
+<kbd>Last updated: March 2026</kbd>
+
 The code diff dialog view has been improved. The Git Integration for Jira app uses the correct syntax highlighting when viewing the code diff of the file based on its file extension:
 
 |     |     |

--- a/git-integration-for-jira-cloud/commit-msg-hook-gij-cloud.md
+++ b/git-integration-for-jira-cloud/commit-msg-hook-gij-cloud.md
@@ -1,9 +1,22 @@
 ---
-title: Commit-msg Hook
-description: Configure the commit-msg client-side hook to validate Jira ticket references in commit messages.
+title: "Commit-msg Hook"
+description: "Configure the commit-msg client-side hook to validate Jira ticket references in commit messages."
+product: "Git Integration for Jira Cloud"
+feature: "Commit-msg Hook"
+content_type: "faq"
+audience: "all"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "all"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "faq"]
 taxonomy:
     category: git-integration-for-jira-cloud
 ---
+<kbd>Last updated: March 2026</kbd>
 
 The commit-msg hook validates commit messages before they're accepted. Use this client-side hook to ensure all commits reference valid Jira tickets.
 
@@ -147,5 +160,3 @@ if err_msg:
     print >> sys.stderr, 'Error: %s\nCommit message:\n%s' % (err_msg, msg)
     sys.exit(1)
 ```
-
-<kbd>Last updated: December 2025</kbd>

--- a/git-integration-for-jira-cloud/connected-apps-gij-cloud.md
+++ b/git-integration-for-jira-cloud/connected-apps-gij-cloud.md
@@ -1,11 +1,22 @@
 ---
-
-title: Connected apps
-description: Learn how to enable or disable GitKraken integration and deep linking features in Git Integration for Jira Cloud.
+title: "Connected apps"
+description: "Learn how to enable or disable GitKraken integration and deep linking features in Git Integration for Jira Cloud."
+product: "Git Integration for Jira Cloud"
+feature: "Connected apps"
+content_type: "concept"
+audience: "all"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "all"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "concept"]
 taxonomy:
     category: git-integration-for-jira-cloud
-
 ---
+<kbd>Last updated: March 2026</kbd>
 
 <!-- FEATURES: USER SETTINGS -->
 
@@ -28,5 +39,3 @@ When enabled, deep linking lets you open commits, branches, tags, and repositori
 [**Prev:** User Settings (index)](/git-integration-for-jira-cloud/user-settings-gij-cloud)
 
 [**Next:** Default branch feature](/git-integration-for-jira-cloud/default-branch-feature-gij-cloud)
-
-<kbd>Last updated: December 2025</kbd>

--- a/git-integration-for-jira-cloud/connecting-ssh-git-repositories-to-jira-cloud-gij-cloud.md
+++ b/git-integration-for-jira-cloud/connecting-ssh-git-repositories-to-jira-cloud-gij-cloud.md
@@ -1,9 +1,22 @@
 ---
-title: Connecting SSH Git Repositories to Jira Cloud
-description: Learn how to connect SSH git repositories to Jira Cloud, including SSH key generation and configuration.
+title: "Connecting SSH Git Repositories to Jira Cloud"
+description: "Learn how to connect SSH git repositories to Jira Cloud, including SSH key generation and configuration."
+product: "Git Integration for Jira Cloud"
+feature: "Connecting SSH Git Repositories to Jira Cloud"
+content_type: "security"
+audience: "all"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "all"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "security"]
 taxonomy:
     category: git-integration-for-jira-cloud
 ---
+<kbd>Last updated: March 2026</kbd>
 
 Connect SSH git repositories to Jira Cloud using [Git Integration for Jira](https://marketplace.atlassian.com/apps/4984/git-integration-for-jira?hosting=cloud&tab=overview).
 
@@ -130,5 +143,3 @@ The connected repository appears in your git configuration page.
     </div>
     </div>
 </div>
-
-<kbd>Last updated: December 2025</kbd>

--- a/git-integration-for-jira-cloud/connecting-to-a-single-git-repository-http-https-gij-cloud.md
+++ b/git-integration-for-jira-cloud/connecting-to-a-single-git-repository-http-https-gij-cloud.md
@@ -1,11 +1,22 @@
 ---
-
-title: Connecting to a Single Git Repository
-description: Learn how to connect a single git repository to Jira Cloud using HTTP/HTTPS or SSH protocols with Git Integration for Jira.
+title: "Connecting to a Single Git Repository"
+description: "Learn how to connect a single git repository to Jira Cloud using HTTP/HTTPS or SSH protocols with Git Integration for Jira."
+product: "Git Integration for Jira Cloud"
+feature: "Connecting to a Single Git Repository"
+content_type: "security"
+audience: "admin"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "Jira Administrator"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "security", "admin"]
 taxonomy:
     category: git-integration-for-jira-cloud
-
 ---
+<kbd>Last updated: March 2026</kbd>
 
 This guide covers connecting a single git repository to Jira using either HTTP/HTTPS or SSH protocols.
 
@@ -111,6 +122,3 @@ You may configure repository settings for this integration via:
 [**Next:** Setting up weblinks](/git-integration-for-jira-cloud/setting-up-web-links-gij-cloud)
 
 <br>
-
-<kbd>Last updated: December 2025</kbd>
-

--- a/git-integration-for-jira-cloud/create-branch-gij-cloud.md
+++ b/git-integration-for-jira-cloud/create-branch-gij-cloud.md
@@ -1,11 +1,22 @@
 ---
-
-title: Create Branch and Pull/Merge Request
-description: Learn how to create branches and pull/merge requests directly from Jira issues using Git Integration for Jira Cloud.
+title: "Create Branch and Pull/Merge Request"
+description: "Learn how to create branches and pull/merge requests directly from Jira issues using Git Integration for Jira Cloud."
+product: "Git Integration for Jira Cloud"
+feature: "Create Branch and Pull/Merge Request"
+content_type: "concept"
+audience: "admin"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "Jira Administrator"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "concept", "admin"]
 taxonomy:
     category: git-integration-for-jira-cloud
-
 ---
+<kbd>Last updated: March 2026</kbd>
 
 <!-- FEATURES -->
 
@@ -286,5 +297,3 @@ Additionally, creating a PR/MR via the Git developer panel automatically associa
     </div>
     </div>
 </div>
-
-<kbd>Last updated: December 2025</kbd>

--- a/git-integration-for-jira-cloud/creating-indexing-triggers-for-a-single-repository-gij-cloud.md
+++ b/git-integration-for-jira-cloud/creating-indexing-triggers-for-a-single-repository-gij-cloud.md
@@ -1,9 +1,22 @@
 ---
-title: Creating indexing triggers for a single repository
-description: Create indexing triggers for individual repositories using webhooks with Git Integration for Jira Cloud.
+title: "Creating indexing triggers for a single repository"
+description: "Create indexing triggers for individual repositories using webhooks with Git Integration for Jira Cloud."
+product: "Git Integration for Jira Cloud"
+feature: "Creating indexing triggers for a single repository"
+content_type: "integration"
+audience: "all"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "all"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "integration"]
 taxonomy:
     category: git-integration-for-jira-cloud
 ---
+<kbd>Last updated: March 2026</kbd>
 
 Create an indexing trigger for any individual repository. Use this with continuous integration services to trigger immediate reindexing.
 
@@ -47,5 +60,3 @@ Create a `payload.json` file with the repository origin:
     "origin": "repository-origin"
 }
 ```
-
-<kbd>Last updated: December 2025</kbd>

--- a/git-integration-for-jira-cloud/creating-personal-access-tokens-gij-cloud.md
+++ b/git-integration-for-jira-cloud/creating-personal-access-tokens-gij-cloud.md
@@ -1,9 +1,22 @@
 ---
-title: Creating Personal Access Tokens
-description: Create personal access tokens (PATs) for GitHub, GitLab, Azure DevOps, TFS, and AWS CodeCommit to authenticate with Git Integration for Jira Cloud.
+title: "Creating Personal Access Tokens"
+description: "Create personal access tokens (PATs) for GitHub, GitLab, Azure DevOps, TFS, and AWS CodeCommit to authenticate with Git Integration for Jira Cloud."
+product: "Git Integration for Jira Cloud"
+feature: "Creating Personal Access Tokens"
+content_type: "security"
+audience: "all"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: ["GitHub", "GitLab", "Azure DevOps Server", "AWS CodeCommit"]
+role_required: "all"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "security", "GitHub", "GitLab", "Azure DevOps Server"]
 taxonomy:
     category: git-integration-for-jira-cloud
 ---
+<kbd>Last updated: March 2026</kbd>
 
 Personal access tokens (PATs) provide secure authentication for connecting git services to Git Integration for Jira Cloud. This page provides step-by-step instructions for creating PATs on each supported git host.
 
@@ -252,5 +265,3 @@ Grant these [AWS CodeCommit IAM Policy actions](https://docs.aws.amazon.com/IAM/
     </div>
     </div>
 </div>
-
-<kbd>Last updated: December 2025</kbd>

--- a/git-integration-for-jira-cloud/default-branch-feature-gij-cloud.md
+++ b/git-integration-for-jira-cloud/default-branch-feature-gij-cloud.md
@@ -1,11 +1,22 @@
 ---
-
-title: Default branch feature
-description: Learn how to configure default branches for repositories when creating new branches from Jira issues.
+title: "Default branch feature"
+description: "Learn how to configure default branches for repositories when creating new branches from Jira issues."
+product: "Git Integration for Jira Cloud"
+feature: "Default branch feature"
+content_type: "integration"
+audience: "all"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "all"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "integration"]
 taxonomy:
     category: git-integration-for-jira-cloud
-
 ---
+<kbd>Last updated: March 2026</kbd>
 
 ![](/wp-content/uploads/gij-gitcloud-user-settings-default-branches.png)
 
@@ -33,5 +44,3 @@ Assign a branch for the selected repository using this interface:
 [**Prev:** Connected apps](/git-integration-for-jira-cloud/connected-apps-gij-cloud)
 
 [**Next:** Default repository feature](/git-integration-for-jira-cloud/default-repository-feature-gij-cloud)
-
-<kbd>Last updated: December 2025</kbd>

--- a/git-integration-for-jira-cloud/default-repository-feature-gij-cloud.md
+++ b/git-integration-for-jira-cloud/default-repository-feature-gij-cloud.md
@@ -1,11 +1,22 @@
 ---
-
-title: Default repository feature
-description: Learn how to set default repositories for Jira projects when using the Create Branch and Create Pull Request features.
+title: "Default repository feature"
+description: "Learn how to set default repositories for Jira projects when using the Create Branch and Create Pull Request features."
+product: "Git Integration for Jira Cloud"
+feature: "Default repository feature"
+content_type: "concept"
+audience: "developer"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "User"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "concept", "developer"]
 taxonomy:
     category: git-integration-for-jira-cloud
-
 ---
+<kbd>Last updated: March 2026</kbd>
 
 Set the default repository for a Jira project when using the [Create Branch](/git-integration-for-jira-cloud/create-branch-gij-cloud) and [Create pull/merge request](/git-integration-for-jira-cloud/create-pull-or-merge-request-gij-cloud) features.
 
@@ -62,5 +73,3 @@ In the above example, the selected default repository displays a DEFAULT label. 
 [**Prev:** Default branch feature](/git-integration-for-jira-cloud/default-branch-feature-gij-cloud)
 
 [**Next:** Personal access token feature](/git-integration-for-jira-cloud/personal-access-token-feature-gij-cloud)
-
-<kbd>Last updated: December 2025</kbd>

--- a/git-integration-for-jira-cloud/deprecation-notice-gij-cloud.md
+++ b/git-integration-for-jira-cloud/deprecation-notice-gij-cloud.md
@@ -1,9 +1,22 @@
 ---
-title: Deprecation notice (GIJ Cloud)
-description: Features and functionality being deprecated or removed from Git Integration for Jira Cloud.
+title: "Deprecation notice (GIJ Cloud)"
+description: "Features and functionality being deprecated or removed from Git Integration for Jira Cloud."
+product: "Git Integration for Jira Cloud"
+feature: "Deprecation notice (GIJ Cloud)"
+content_type: "concept"
+audience: "admin"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "Jira Administrator"
+version_required: "all"
+status: "deprecated"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "concept", "admin", "deprecated"]
 taxonomy:
     category: git-integration-for-jira-cloud
 ---
+<kbd>Last updated: March 2026</kbd>
 
 This page lists features and functionality that are deprecated or scheduled for removal from Git Integration for Jira Cloud.
 
@@ -14,5 +27,3 @@ This page lists features and functionality that are deprecated or scheduled for 
 | Ignore unmatching webhooks | September 14, 2021 | Git Integration for Jira no longer reindexes all repositories by default when a webhook arrives without a matching repository. |
 | GitLab legacy integrations | June 6, 2023 | Support for GitLab legacy integrations dropped in v4.19+. |
 | GitLab legacy integrations removal | End of March 2024 | GitLab legacy integrations deprecated in the Manage integrations screen. Upgrade your GitLab server, remove legacy integrations, and connect a new GitLab CE/EE integration. |
-
-<kbd>Last updated: December 2025</kbd>

--- a/git-integration-for-jira-cloud/edit-integration-gij-cloud.md
+++ b/git-integration-for-jira-cloud/edit-integration-gij-cloud.md
@@ -1,11 +1,22 @@
 ---
-
-title: Edit integration settings
-description: How to configure integration connection and feature settings
+title: "Edit integration settings"
+description: "How to configure integration connection and feature settings"
+product: "Git Integration for Jira Cloud"
+feature: "Edit integration settings"
+content_type: "integration"
+audience: "admin"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "Jira Administrator"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "integration", "admin"]
 taxonomy:
     category: git-integration-for-jira-cloud
-
 ---
+<kbd>Last updated: March 2026</kbd>
 
 On the Manage integrations page, click <img src='/wp-content/uploads/actions-icon.png' style='margin: 0 3px' /> Actions ➜ **Edit integration** for the selected integration to open its configuration page.
 
@@ -106,5 +117,3 @@ Click **Save** to save the changes and apply the integration settings.
 [Associating project permissions](/git-integration-for-jira-cloud/associating-project-permissions-gij-cloud/) (Git Integration for Jira Cloud)
 
 <p>&nbsp;</p>
-
-<p style="text-align: center; margin: 0; padding: 0;"><kbd>Last updated: December 2025</kbd></p>

--- a/git-integration-for-jira-cloud/edit-nested-repository-settings-gij-cloud.md
+++ b/git-integration-for-jira-cloud/edit-nested-repository-settings-gij-cloud.md
@@ -1,11 +1,22 @@
 ---
-
-title: Edit nested repository settings
-description: How to modify nested repository configuration settings
+title: "Edit nested repository settings"
+description: "How to modify nested repository configuration settings"
+product: "Git Integration for Jira Cloud"
+feature: "Edit nested repository settings"
+content_type: "integration"
+audience: "all"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "all"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "integration"]
 taxonomy:
     category: git-integration-for-jira-cloud
-
 ---
+<kbd>Last updated: March 2026</kbd>
 
 Modify nested repository settings via the Manage repositories page.
 
@@ -107,5 +118,3 @@ Use the options below to configure repository settings:
 [Associating project permissions](/git-integration-for-jira-cloud/associating-project-permissions-gij-cloud/) (Git Integration for Jira Cloud)
 
 <p>&nbsp;</p>
-
-<p style="text-align: center; margin: 0; padding: 0;"><kbd>Last updated: December 2025</kbd></p>

--- a/git-integration-for-jira-cloud/edit-repository-gij-cloud.md
+++ b/git-integration-for-jira-cloud/edit-repository-gij-cloud.md
@@ -1,11 +1,22 @@
 ---
-
-title: Edit repository settings
-description: How to configure repository connection and feature settings
+title: "Edit repository settings"
+description: "How to configure repository connection and feature settings"
+product: "Git Integration for Jira Cloud"
+feature: "Edit repository settings"
+content_type: "integration"
+audience: "all"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "all"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "integration"]
 taxonomy:
     category: git-integration-for-jira-cloud
-
 ---
+<kbd>Last updated: March 2026</kbd>
 
 <b style='background-color:#DEE0E5; padding:1px 5px; color:#44516C; border-radius:3px; margin: 0 5px; font-size: small;'>HOSTED</b> <b style='background-color:#DEEAFE; padding:1px 5px; color:#0C42A3; border-radius:3px; margin: 0 5px; font-size: small;'>EXTERNAL</b>
 
@@ -80,5 +91,3 @@ Click **Cancel** to return to the manage git configuration page and discard the 
 [Associating project permissions](/git-integration-for-jira-cloud/associating-project-permissions-gij-cloud/) (Git Integration for Jira Cloud)
 
 <p>&nbsp;</p>
-
-<p style="text-align: center; margin: 0; padding: 0;"><kbd>Last updated: December 2025</kbd></p>

--- a/git-integration-for-jira-cloud/feature-matrix-of-git-integration-for-jira-cloud-gij-cloud.md
+++ b/git-integration-for-jira-cloud/feature-matrix-of-git-integration-for-jira-cloud-gij-cloud.md
@@ -1,11 +1,23 @@
 ---
-
-title: Feature matrix of Git Integration for Jira Cloud
-description: Compare features available across different integration types including git service integrations, single repositories, and webhook indexing.
+title: "Feature matrix of Git Integration for Jira Cloud"
+description: "Compare features available across different integration types including git service integrations, single repositories, and webhook indexing."
+product: "Git Integration for Jira Cloud"
+feature: "Feature matrix of Git Integration for Jira Cloud"
+content_type: "reference"
+audience: "admin"
+plan_required: "Standard, Advanced"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "Jira Administrator"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "reference", "admin", "Standard, Advanced"]
 taxonomy:
     category: git-integration-for-jira-cloud
-
 ---
+<kbd>Last updated: March 2026</kbd>
+
 See also [Feature Comparison](/git-integration-for-jira-cloud/git-integration-server-data-center-vs-jira-cloud-feature-comparison-gij-cloud) for information on features and differences between Git Integration for Server/Data Center versus Git Integration for Jira Cloud.
 
 [Git Integration for Jira Cloud](https://marketplace.atlassian.com/apps/4984/git-integration-for-jira?hosting=cloud&tab=overview) offers various integration options and features. The matrix below shows which features each integration type supports. For questions, contact [BigBrassBand Support](https://help.gitkraken.com/git-integration-for-jira-cloud/gij-cloud-contact-support/).
@@ -60,5 +72,3 @@ See also [Feature Comparison](/git-integration-for-jira-cloud/git-integration-se
     </div>
     </div>
 </div>
-
-<kbd>Last updated: December 2025</kbd>

--- a/git-integration-for-jira-cloud/features-gij-cloud.md
+++ b/git-integration-for-jira-cloud/features-gij-cloud.md
@@ -1,11 +1,22 @@
 ---
-
-title: Features
-description: Overview of Git Integration for Jira Cloud features including deep linking, CI/CD integration, automation, and repository management.
+title: "Features"
+description: "Overview of Git Integration for Jira Cloud features including deep linking, CI/CD integration, automation, and repository management."
+product: "Git Integration for Jira Cloud"
+feature: "Features"
+content_type: "concept"
+audience: "all"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "all"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "concept"]
 taxonomy:
     category: git-integration-for-jira-cloud
-
 ---
+<kbd>Last updated: March 2026</kbd>
 
 Explore the features available in Git Integration for Jira Cloud. Select a topic below to learn more.
 
@@ -32,5 +43,3 @@ Explore the features available in Git Integration for Jira Cloud. Select a topic
 - [Migrating from Jira Server + Data Center to Jira Cloud](/git-integration-for-jira-cloud/migrating-from-jira-server-data-center-to-jira-cloud-gij-cloud)
 - [User Settings](/git-integration-for-jira-cloud/user-settings-gij-cloud)
 - [General Settings](/git-integration-for-jira-cloud/general-settings-gij-cloud)
-
-<kbd>Last updated: December 2025</kbd>

--- a/git-integration-for-jira-cloud/frequently-asked-questions-gij-cloud.md
+++ b/git-integration-for-jira-cloud/frequently-asked-questions-gij-cloud.md
@@ -1,9 +1,22 @@
 ---
-title: Frequently Asked Questions
-description: Find answers to common questions about Git Integration for Jira Cloud, including setup, configuration, and troubleshooting.
+title: "Frequently Asked Questions"
+description: "Find answers to common questions about Git Integration for Jira Cloud, including setup, configuration, and troubleshooting."
+product: "Git Integration for Jira Cloud"
+feature: "Frequently Asked Questions"
+content_type: "faq"
+audience: "all"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "all"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "faq"]
 taxonomy:
     category: git-integration-for-jira-cloud
 ---
+<kbd>Last updated: March 2026</kbd>
 
 Find answers to questions asked by Git Integration for Jira app users. Use the table of contents below to jump to a specific topic.
 
@@ -318,5 +331,3 @@ Yes. Unicode characters are supported and displayed properly.
 ![](/wp-content/uploads/App-Information2-2025.png)
 
 Include this information in support requests.
-
-<kbd>Last updated: December 2025</kbd>

--- a/git-integration-for-jira-cloud/general-settings-for-administrators-gij-cloud.md
+++ b/git-integration-for-jira-cloud/general-settings-for-administrators-gij-cloud.md
@@ -1,9 +1,22 @@
 ---
-title: General settings for administrators
-description: Overview of general settings configuration for Jira administrators using Git Integration for Jira Cloud.
+title: "General settings for administrators"
+description: "Overview of general settings configuration for Jira administrators using Git Integration for Jira Cloud."
+product: "Git Integration for Jira Cloud"
+feature: "General settings for administrators"
+content_type: "admin"
+audience: "admin"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "Jira Administrator"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "admin"]
 taxonomy:
     category: git-integration-for-jira-cloud
 ---
+<kbd>Last updated: March 2026</kbd>
 
 <div class="bbb-callout bbb--info">
     <div class="irow">
@@ -55,5 +68,3 @@ For detailed information about available settings, see [General settings](/git-i
 [**Next:** Web linking](/git-integration-for-jira-cloud/web-linking-gij-cloud/)
 
 <p>&nbsp;</p>
-
-<p style="text-align: center; margin: 0; padding: 0;"><kbd>Last updated: December 2025</kbd></p>

--- a/git-integration-for-jira-cloud/general-settings-gij-cloud.md
+++ b/git-integration-for-jira-cloud/general-settings-gij-cloud.md
@@ -1,11 +1,22 @@
 ---
-
-title: General Settings
-description: Configure Git Integration for Jira Cloud general settings including development panel options, branch naming, and integration features.
+title: "General Settings"
+description: "Configure Git Integration for Jira Cloud general settings including development panel options, branch naming, and integration features."
+product: "Git Integration for Jira Cloud"
+feature: "General Settings"
+content_type: "admin"
+audience: "admin"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "Jira Administrator"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "admin"]
 taxonomy:
     category: git-integration-for-jira-cloud
-
 ---
+<kbd>Last updated: March 2026</kbd>
 
 <!-- ADMINS -->
 
@@ -611,5 +622,3 @@ Click **Update** to apply your configuration changes.
 ## Related articles
 
 [General settings for administrators](/git-integration-for-jira-cloud/general-settings-for-administrators-gij-cloud) (Git Integration for Jira Cloud)
-
-<kbd>Last updated: December 2025</kbd>

--- a/git-integration-for-jira-cloud/gerrit-gij-cloud.md
+++ b/git-integration-for-jira-cloud/gerrit-gij-cloud.md
@@ -1,11 +1,22 @@
 ---
-
-title: Gerrit
-description: Learn how to integrate Gerrit git repositories with Jira Cloud using Git Integration for Jira.
+title: "Gerrit"
+description: "Learn how to integrate Gerrit git repositories with Jira Cloud using Git Integration for Jira."
+product: "Git Integration for Jira Cloud"
+feature: "Gerrit"
+content_type: "integration"
+audience: "admin"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: ["Gerrit"]
+role_required: "Jira Administrator"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "integration", "admin", "Gerrit"]
 taxonomy:
     category: git-integration-for-jira-cloud
-
 ---
+<kbd>Last updated: March 2026</kbd>
 
 <div class="bbb-callout bbb--info">
     <div class="irow">
@@ -182,6 +193,3 @@ For the case with Gerrit, the default main branch is always “master”.
 [Introduction to Git integration](/git-integration-for-jira-cloud/integration-guide-gij-cloud)
 
 <br>
-
-<kbd>Last updated: December 2025</kbd>
-

--- a/git-integration-for-jira-cloud/gerrit-webhook-indexing-integration-gij-cloud.md
+++ b/git-integration-for-jira-cloud/gerrit-webhook-indexing-integration-gij-cloud.md
@@ -1,9 +1,22 @@
 ---
-title: Gerrit webhook indexing integration
-description: Configure webhook indexing integration for Gerrit to work with Git Integration for Jira Cloud behind firewalls.
+title: "Gerrit webhook indexing integration"
+description: "Configure webhook indexing integration for Gerrit to work with Git Integration for Jira Cloud behind firewalls."
+product: "Git Integration for Jira Cloud"
+feature: "Gerrit webhook indexing integration"
+content_type: "reference"
+audience: "all"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: ["Gerrit"]
+role_required: "all"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "reference", "Gerrit"]
 taxonomy:
     category: git-integration-for-jira-cloud
 ---
+<kbd>Last updated: March 2026</kbd>
 
 <div class="bbb-callout bbb--info">
     <div class="irow">
@@ -23,5 +36,3 @@ taxonomy:
 - [GitHub webhook indexing integration](/git-integration-for-jira-cloud/github-webhook-indexing-integration-gij-cloud)
 - [GitLab webhook indexing integration](/git-integration-for-jira-cloud/gitlab-webhook-indexing-integration-gij-cloud)
 - [Microsoft webhook indexing integration](/git-integration-for-jira-cloud/microsoft-webhook-indexing-integration-gij-cloud)
-
-<kbd>Last updated: December 2025</kbd>

--- a/git-integration-for-jira-cloud/git-commits-issue-tab-and-project-pages-gij-cloud.md
+++ b/git-integration-for-jira-cloud/git-commits-issue-tab-and-project-pages-gij-cloud.md
@@ -1,11 +1,22 @@
 ---
-
-title: Git Commits Issue Tab and Project Pages (Features)
-description: Learn how to view git commits associated with Jira issues and projects using the Git Commits Issue Tab and Project Page.
+title: "Git Commits Issue Tab and Project Pages (Features)"
+description: "Learn how to view git commits associated with Jira issues and projects using the Git Commits Issue Tab and Project Page."
+product: "Git Integration for Jira Cloud"
+feature: "Git Commits Issue Tab and Project Pages (Features)"
+content_type: "concept"
+audience: "admin"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "Jira Administrator"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "concept", "admin"]
 taxonomy:
     category: git-integration-for-jira-cloud
-
 ---
+<kbd>Last updated: March 2026</kbd>
 
 <!-- FEATURES -->
 
@@ -118,5 +129,3 @@ The Change association feature allows you to update the Jira issues associated w
 - [Git Integration Server/Data Center vs Jira Cloud – Feature Comparison](/git-integration-for-jira-cloud/git-integration-server-data-center-vs-jira-cloud-feature-comparison-gij-cloud/)
 - [Migrating from Jira Server + Data Center to Jira Cloud](/git-integration-for-jira-cloud/migrating-from-jira-server-data-center-to-jira-cloud-gij-cloud/)
 - [User Settings](/git-integration-for-jira-cloud/user-settings-gij-cloud/)
-
-<kbd>Last updated: December 2025</kbd>

--- a/git-integration-for-jira-cloud/git-integration-for-jira-cloud-release-notes-gij-cloud.md
+++ b/git-integration-for-jira-cloud/git-integration-for-jira-cloud-release-notes-gij-cloud.md
@@ -1,11 +1,22 @@
 ---
-
-title: Git Integration for Jira Cloud - Release Notes
-description: Release notes documenting new features, improvements, bug fixes, and security updates for Git Integration for Jira Cloud
+title: "Git Integration for Jira Cloud - Release Notes"
+description: "Release notes documenting new features, improvements, bug fixes, and security updates for Git Integration for Jira Cloud"
+product: "Git Integration for Jira Cloud"
+feature: "Git Integration for Jira Cloud - Release Notes"
+content_type: "reference"
+audience: "admin"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "Jira Administrator"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "reference", "admin"]
 taxonomy:
     category: git-integration-for-jira-cloud
-
 ---
+<kbd>Last updated: March 2026</kbd>
 
 We publish new features, bug fixes, security updates, and Jira compatibility improvements regularly. Below are highlights of the changes.
 

--- a/git-integration-for-jira-cloud/git-integration-for-jira-home-gij-cloud.md
+++ b/git-integration-for-jira-cloud/git-integration-for-jira-home-gij-cloud.md
@@ -1,11 +1,22 @@
 ---
-
-title: Git Integration for Jira Cloud Support Home
-description: Your source for Git Integration for Jira Cloud documentation
+title: "Git Integration for Jira Cloud Support Home"
+description: "Your source for Git Integration for Jira Cloud documentation"
+product: "Git Integration for Jira Cloud"
+feature: "Git Integration for Jira Cloud Support Home"
+content_type: "troubleshooting"
+audience: "all"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "all"
+version_required: "all"
+status: "deprecated"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "troubleshooting", "deprecated"]
 taxonomy:
     category: git-integration-for-jira-cloud
-
 ---
+<kbd>Last updated: March 2026</kbd>
 
 Welcome to the Git Integration for Jira Cloud documentation. Use the links below to get started, or explore the left navigation for more topics.
 
@@ -56,5 +67,3 @@ Have an idea for improving Git Integration for Jira, found a bug, or need techni
 [Contact Support](https://help.gitkraken.com/git-integration-for-jira-cloud/gij-cloud-contact-support/)
 
 <p>&nbsp;</p>
-
-<p style="text-align: center; margin: 0; padding: 0;"><kbd>Last updated: December 2025</kbd></p>

--- a/git-integration-for-jira-cloud/git-integration-jira-automation-gij-cloud.md
+++ b/git-integration-for-jira-cloud/git-integration-jira-automation-gij-cloud.md
@@ -1,11 +1,22 @@
 ---
-
-title: Git Integration + Jira Automation
-description: Learn how to configure Jira automation rules with Git Integration for Jira Cloud triggers for branches, commits, and pull requests.
+title: "Git Integration + Jira Automation"
+description: "Learn how to configure Jira automation rules with Git Integration for Jira Cloud triggers for branches, commits, and pull requests."
+product: "Git Integration for Jira Cloud"
+feature: "Git Integration + Jira Automation"
+content_type: "integration"
+audience: "developer"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "User"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "integration", "developer"]
 taxonomy:
     category: git-integration-for-jira-cloud
-
 ---
+<kbd>Last updated: March 2026</kbd>
 
 <b style='background-color:#E2FCEF; padding:1px 5px; color:#006745; border-radius:3px; margin: 0 5px; font-size: small;'>JIRA CLOUD</b> &mdash; <b>AVAILABLE!</b><br>
 <b style='background-color:#DEEAFE; padding:1px 5px; color:#0C42A3; border-radius:3px; margin: 0 5px; font-size: small;'>JIRA SERVER / DATA CENTER</b> &mdash; <b>AVAILABLE!</b>
@@ -214,5 +225,3 @@ Git Integration for Jira currently supports the five highlighted triggers shown 
 - [Automation basics](https://www.atlassian.com/software/jira/guides/expand-jira/automation)
 - [What are smart values?](https://support.atlassian.com/jira-software-cloud/docs/what-are-smart-values/)
 - [Automation conditions](https://support.atlassian.com/jira-software-cloud/docs/automation-conditions/)
-
-<kbd>Last updated: December 2025</kbd>

--- a/git-integration-for-jira-cloud/git-integration-jira-cloud-video-guides-gij-cloud.md
+++ b/git-integration-for-jira-cloud/git-integration-jira-cloud-video-guides-gij-cloud.md
@@ -1,9 +1,22 @@
 ---
-title: Git Integration (Jira Cloud) - Video Guides
-description: Watch video tutorials covering installation, integration, administration, and customization of Git Integration for Jira Cloud.
+title: "Git Integration (Jira Cloud) - Video Guides"
+description: "Watch video tutorials covering installation, integration, administration, and customization of Git Integration for Jira Cloud."
+product: "Git Integration for Jira Cloud"
+feature: "Git Integration (Jira Cloud) - Video Guides"
+content_type: "install"
+audience: "admin"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "Jira Administrator"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "install", "admin"]
 taxonomy:
     category: git-integration-for-jira-cloud
 ---
+<kbd>Last updated: March 2026</kbd>
 
 These video tutorials walk you through key features of Git Integration for Jira Cloud, including installation, connecting git hosts, and viewing commits from Jira.
 
@@ -104,5 +117,3 @@ Generate personal access tokens with the required scopes for self-hosted GitLab 
 **[Enable App Update Notifications »](https://gitkraken.wistia.com/medias/u9rojnv0vv)**
 
 Configure Jira preferences to receive notifications when app updates are available.
-
-<kbd>Last updated: December 2025</kbd>

--- a/git-integration-for-jira-cloud/git-integration-server-data-center-vs-jira-cloud-feature-comparison-gij-cloud.md
+++ b/git-integration-for-jira-cloud/git-integration-server-data-center-vs-jira-cloud-feature-comparison-gij-cloud.md
@@ -1,11 +1,22 @@
 ---
-
-title: Git Integration Server/Data Center vs Jira Cloud - Feature Comparison
-description: Compare features between Git Integration for Jira Server/Data Center and Git Integration for Jira Cloud.
+title: "Git Integration Server/Data Center vs Jira Cloud - Feature Comparison"
+description: "Compare features between Git Integration for Jira Server/Data Center and Git Integration for Jira Cloud."
+product: "Git Integration for Jira Cloud"
+feature: "Git Integration Server/Data Center vs Jira Cloud - Feature Comparison"
+content_type: "reference"
+audience: "developer"
+plan_required: "Standard, Advanced"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "User"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "reference", "developer", "Standard, Advanced"]
 taxonomy:
     category: git-integration-for-jira-cloud
-
 ---
+<kbd>Last updated: March 2026</kbd>
 
 <div class="bbb-callout bbb--info">
     <div class="irow">
@@ -563,5 +574,3 @@ Git Integration for Jira Data Center</th>
 </div>
 </div>
 <br>
-
-<kbd>Last updated: December 2025</kbd>

--- a/git-integration-for-jira-cloud/git-roll-up-issue-tab-gij-cloud.md
+++ b/git-integration-for-jira-cloud/git-roll-up-issue-tab-gij-cloud.md
@@ -1,11 +1,22 @@
 ---
-
-title: Git Roll Up Issue Tab (Features)
-description: Learn how to use the Git Roll Up Issue Tab to view commit summaries, file changes, and developer activity in Jira issues.
+title: "Git Roll Up Issue Tab (Features)"
+description: "Learn how to use the Git Roll Up Issue Tab to view commit summaries, file changes, and developer activity in Jira issues."
+product: "Git Integration for Jira Cloud"
+feature: "Git Roll Up Issue Tab (Features)"
+content_type: "concept"
+audience: "admin"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "Jira Administrator"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "concept", "admin"]
 taxonomy:
     category: git-integration-for-jira-cloud
-
 ---
+<kbd>Last updated: March 2026</kbd>
 
 <div class="bbb-callout bbb--info">
     <div class="irow">
@@ -107,5 +118,3 @@ Notable sections include:
 - [Migrating from Jira Server + Data Center to Jira Cloud](/git-integration-for-jira-cloud/migrating-from-jira-server-data-center-to-jira-cloud-gij-cloud)
 - [User Settings](/git-integration-for-jira-cloud/user-settings-gij-cloud)
 - [General Settings](/git-integration-for-jira-cloud/general-settings-gij-cloud)
-
-<kbd>Last updated: December 2025</kbd>

--- a/git-integration-for-jira-cloud/git-services-support-page-and-end-of-life-policies-gij-cloud.md
+++ b/git-integration-for-jira-cloud/git-services-support-page-and-end-of-life-policies-gij-cloud.md
@@ -1,9 +1,22 @@
 ---
-title: Git Services Support Page and End-of-Life Policies
-description: End-of-life policies and support information for git services compatible with Git Integration for Jira Cloud.
+title: "Git Services Support Page and End-of-Life Policies"
+description: "End-of-life policies and support information for git services compatible with Git Integration for Jira Cloud."
+product: "Git Integration for Jira Cloud"
+feature: "Git Services Support Page and End-of-Life Policies"
+content_type: "reference"
+audience: "all"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "all"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "reference"]
 taxonomy:
     category: git-integration-for-jira-cloud
 ---
+<kbd>Last updated: March 2026</kbd>
 
 Git Integration for Jira Cloud supports all cloud-hosted versions and officially supported versions of self-hosted git services.
 
@@ -96,5 +109,3 @@ The Gerrit open-source community actively supports the last 2 releases on a best
 EOL for old releases occurs when a new Gerrit version is released and is announced via [project news](https://www.gerritcodereview.com/news.html).
 
 For more information, see the [Gerrit support page](https://www.gerritcodereview.com/support.html).
-
-<kbd>Last updated: December 2025</kbd>

--- a/git-integration-for-jira-cloud/git-url-ports-gij-cloud.md
+++ b/git-integration-for-jira-cloud/git-url-ports-gij-cloud.md
@@ -1,11 +1,22 @@
 ---
-
-title: Git URL Ports
-description: Default port configurations for Git URL protocols
+title: "Git URL Ports"
+description: "Default port configurations for Git URL protocols"
+product: "Git Integration for Jira Cloud"
+feature: "Git URL Ports"
+content_type: "install"
+audience: "admin"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "Jira Administrator"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "install", "admin"]
 taxonomy:
     category: git-integration-for-jira-cloud
-
 ---
+<kbd>Last updated: March 2026</kbd>
 
 If your Git servers are running through a firewall, configure the firewall to allow access using the URL schemes for git repositories. For authentication issues, make sure to check the correct port for the connection.
 
@@ -35,5 +46,3 @@ Git Integration for Jira will run successfully if the above connection test comp
 For detailed information on whitelisting your Git server, see [Allow list (whitelist) BigBrassBand Cloud](/git-integration-for-jira-cloud/allow-list-whitelist-bigbrassband-cloud-gij-cloud).
 
 <p>&nbsp;</p>
-
-<p style="text-align: center; margin: 0; padding: 0;"><kbd>Last updated: December 2025</kbd></p>

--- a/git-integration-for-jira-cloud/git-user-identity-gij-cloud.md
+++ b/git-integration-for-jira-cloud/git-user-identity-gij-cloud.md
@@ -1,11 +1,22 @@
 ---
-
-title: Git User Identity
-description: How Git user identity is configured and displayed in Jira
+title: "Git User Identity"
+description: "How Git user identity is configured and displayed in Jira"
+product: "Git Integration for Jira Cloud"
+feature: "Git User Identity"
+content_type: "integration"
+audience: "all"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "all"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "integration"]
 taxonomy:
     category: git-integration-for-jira-cloud
-
 ---
+<kbd>Last updated: March 2026</kbd>
 
 A git user can identify themselves on their local computer using the following commands:
 
@@ -43,5 +54,3 @@ Hosting services (like GitHub and Bitbucket, for example) try to match this data
 [**Next:** Jira user information card](/git-integration-for-jira-cloud/jira-user-information-card-gij-cloud)
 
 <p>&nbsp;</p>
-
-<p style="text-align: center; margin: 0; padding: 0;"><kbd>Last updated: December 2025</kbd></p>

--- a/git-integration-for-jira-cloud/github-app-gij-cloud.md
+++ b/git-integration-for-jira-cloud/github-app-gij-cloud.md
@@ -1,11 +1,22 @@
 ---
-
-title: GitHub App integration
-description: How to integrate GitHub repositories using the GitHub App with Jira Cloud
+title: "GitHub App integration"
+description: "How to integrate GitHub repositories using the GitHub App with Jira Cloud"
+product: "Git Integration for Jira Cloud"
+feature: "GitHub App integration"
+content_type: "install"
+audience: "admin"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: ["GitHub"]
+role_required: "Jira Administrator"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "install", "admin", "GitHub"]
 taxonomy:
     category: git-integration-for-jira-cloud
-
 ---
+<kbd>Last updated: March 2026</kbd>
 
 GitHub offers several integration options: API, OAuth, and GitHub Apps. GitHub Apps provide these advantages over OAuth:
 
@@ -152,5 +163,3 @@ Git Integration for Jira creates the GitHub App automatically. For questions, co
 ### More Git Integration for Jira app features
 
 See the [Features section](/git-integration-for-jira-cloud/features-gij-cloud) to learn more about Git Integration for Jira app features.
-
-<kbd>Last updated: December 2025</kbd>

--- a/git-integration-for-jira-cloud/github-com-gij-cloud.md
+++ b/git-integration-for-jira-cloud/github-com-gij-cloud.md
@@ -1,11 +1,22 @@
 ---
-
-title: GitHub.com
-description: Integrate GitHub.com repositories with Jira Cloud using Git Integration for Jira.
+title: "GitHub.com"
+description: "Integrate GitHub.com repositories with Jira Cloud using Git Integration for Jira."
+product: "Git Integration for Jira Cloud"
+feature: "GitHub.com"
+content_type: "integration"
+audience: "admin"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: ["GitHub.com"]
+role_required: "Jira Administrator"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "integration", "admin", "GitHub.com"]
 taxonomy:
     category: git-integration-for-jira-cloud
-
 ---
+<kbd>Last updated: March 2026</kbd>
 
 <div class="bbb-callout bbb--tip">
     <div class="irow">
@@ -470,6 +481,3 @@ The pull request is also ready for approval by the reviewers in your GitHub web 
 [Introduction to Git integration](/git-integration-for-jira-cloud/integration-guide-gij-cloud) (Git Integration for Jira Cloud)
 
 <p>&nbsp;</p>
-
-<p style="text-align: center; margin: 0; padding: 0;"><kbd>Last updated: December 2025</kbd></p>
-

--- a/git-integration-for-jira-cloud/github-com-github-enterprise-jmespath-filter-examples-gij-cloud.md
+++ b/git-integration-for-jira-cloud/github-com-github-enterprise-jmespath-filter-examples-gij-cloud.md
@@ -1,11 +1,22 @@
 ---
-
-title: GitHub.com | GitHub Enterprise JMESPath filter examples
-description:
+title: "GitHub.com | GitHub Enterprise JMESPath filter examples"
+description: "Step-by-step guide to GitHub.com | GitHub Enterprise JMESPath filter examples in Git Integration for Jira Cloud for GitHub.com, GitHub, for Jira Cloud users."
+product: "Git Integration for Jira Cloud"
+feature: "GitHub.com | GitHub Enterprise JMESPath filter examples"
+content_type: "integration"
+audience: "all"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: ["GitHub.com"]
+role_required: "all"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "integration", "GitHub.com"]
 taxonomy:
     category: git-integration-for-jira-cloud
-
 ---
+<kbd>Last updated: March 2026</kbd>
 
 &nbsp;
 
@@ -67,4 +78,3 @@ Lists repositories with names that starts with `'git'` or ends with `'test'`.
 *   [Microsoft | VSTS | TFS | Azure Repos JMESPath filter examples](/git-integration-for-jira-cloud/microsoft-vsts-tfs-azure-repos-jmespath-filter-examples-gij-cloud)
 
 *   [Bitbucket JMESPath filter examples](/git-integration-for-jira-cloud/bitbucket-jmespath-filter-examples-gij-cloud)
-

--- a/git-integration-for-jira-cloud/github-enterprise-server-gij-cloud.md
+++ b/git-integration-for-jira-cloud/github-enterprise-server-gij-cloud.md
@@ -1,11 +1,22 @@
 ---
-
-title: GitHub Enterprise Server
-description: How to integrate GitHub Enterprise Server repositories with Jira Cloud
+title: "GitHub Enterprise Server"
+description: "How to integrate GitHub Enterprise Server repositories with Jira Cloud"
+product: "Git Integration for Jira Cloud"
+feature: "GitHub Enterprise Server"
+content_type: "integration"
+audience: "admin"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: ["GitHub Enterprise Server"]
+role_required: "Jira Administrator"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "integration", "admin", "GitHub Enterprise Server"]
 taxonomy:
     category: git-integration-for-jira-cloud
-
 ---
+<kbd>Last updated: March 2026</kbd>
 
 <div class="bbb-callout bbb--tip">
     <div class="irow">
@@ -442,6 +453,3 @@ The pull request is also ready for approval by the reviewers in your GitHub web 
 [Introduction to Git integration](/git-integration-for-jira-cloud/integration-guide-gij-cloud) (Git Integration for Jira Cloud)
 
 <p>&nbsp;</p>
-
-<p style="text-align: center; margin: 0; padding: 0;"><kbd>Last updated: December 2025</kbd></p>
-

--- a/git-integration-for-jira-cloud/github-webhook-events-gij-cloud.md
+++ b/git-integration-for-jira-cloud/github-webhook-events-gij-cloud.md
@@ -1,9 +1,22 @@
 ---
-title: GitHub webhook events
-description: Reference documentation for GitHub webhook event types supported by Git Integration for Jira Cloud.
+title: "GitHub webhook events"
+description: "Reference documentation for GitHub webhook event types supported by Git Integration for Jira Cloud."
+product: "Git Integration for Jira Cloud"
+feature: "GitHub webhook events"
+content_type: "reference"
+audience: "developer"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: ["GitHub"]
+role_required: "User"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "reference", "developer", "GitHub"]
 taxonomy:
     category: git-integration-for-jira-cloud
 ---
+<kbd>Last updated: March 2026</kbd>
 
 This page documents the GitHub webhook event types that Git Integration for Jira Cloud supports.
 
@@ -84,5 +97,3 @@ This page documents the GitHub webhook event types that Git Integration for Jira
 - [Microsoft webhook events](/git-integration-for-jira-cloud/microsoft-webhook-events-gij-cloud)
 - [AWS CodeCommit webhook events](/git-integration-for-jira-cloud/aws-codecommit-webhook-events-gij-cloud)
 - [Bitbucket webhook events](/git-integration-for-jira-cloud/bitbucket-webhook-events-gij-cloud)
-
-<kbd>Last updated: December 2025</kbd>

--- a/git-integration-for-jira-cloud/github-webhook-indexing-integration-gij-cloud.md
+++ b/git-integration-for-jira-cloud/github-webhook-indexing-integration-gij-cloud.md
@@ -1,9 +1,22 @@
 ---
-title: GitHub webhook indexing integration
-description: Configure webhook indexing integration for GitHub.com or GitHub Enterprise Server to work with Git Integration for Jira Cloud behind firewalls.
+title: "GitHub webhook indexing integration"
+description: "Configure webhook indexing integration for GitHub.com or GitHub Enterprise Server to work with Git Integration for Jira Cloud behind firewalls."
+product: "Git Integration for Jira Cloud"
+feature: "GitHub webhook indexing integration"
+content_type: "install"
+audience: "admin"
+plan_required: "Standard, Advanced"
+deployment: "Jira Cloud"
+git_host_support: ["GitHub Enterprise Server", "GitHub.com"]
+role_required: "Jira Administrator"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "install", "admin", "GitHub Enterprise Server", "GitHub.com", "Standard, Advanced"]
 taxonomy:
     category: git-integration-for-jira-cloud
 ---
+<kbd>Last updated: March 2026</kbd>
 
 <div class="bbb-callout bbb--info">
     <div class="irow">
@@ -189,5 +202,3 @@ For complete feature details, see [Feature matrix](/git-integration-for-jira-clo
 - [GitLab webhook indexing integration](/git-integration-for-jira-cloud/gitlab-webhook-indexing-integration-gij-cloud)
 - [Microsoft webhook indexing integration](/git-integration-for-jira-cloud/microsoft-webhook-indexing-integration-gij-cloud)
 - [Gerrit webhook indexing integration](/git-integration-for-jira-cloud/gerrit-webhook-indexing-integration-gij-cloud)
-
-<kbd>Last updated: December 2025</kbd>

--- a/git-integration-for-jira-cloud/gitlab-ce-ee-gij-cloud.md
+++ b/git-integration-for-jira-cloud/gitlab-ce-ee-gij-cloud.md
@@ -1,11 +1,22 @@
 ---
-
-title: GitLab CE/EE
-description: How to integrate GitLab CE/EE repositories with Jira Cloud
+title: "GitLab CE/EE"
+description: "How to integrate GitLab CE/EE repositories with Jira Cloud"
+product: "Git Integration for Jira Cloud"
+feature: "GitLab CE/EE"
+content_type: "integration"
+audience: "admin"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: ["GitLab CE/EE"]
+role_required: "Jira Administrator"
+version_required: "all"
+status: "deprecated"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "integration", "admin", "GitLab CE/EE", "deprecated"]
 taxonomy:
     category: git-integration-for-jira-cloud
-
 ---
+<kbd>Last updated: March 2026</kbd>
 
 <div class="bbb-callout bbb--info">
     <div class="irow">
@@ -501,6 +512,3 @@ The merge request is also ready for approval by the reviewers in your GitLab web
 </div>
 
 <p>&nbsp;</p>
-
-<p style="text-align: center; margin: 0; padding: 0;"><kbd>Last updated: December 2025</kbd></p>
-

--- a/git-integration-for-jira-cloud/gitlab-com-gij-cloud.md
+++ b/git-integration-for-jira-cloud/gitlab-com-gij-cloud.md
@@ -1,11 +1,22 @@
 ---
-
-title: GitLab.com
-description: How to integrate GitLab.com repositories with Jira Cloud
+title: "GitLab.com"
+description: "How to integrate GitLab.com repositories with Jira Cloud"
+product: "Git Integration for Jira Cloud"
+feature: "GitLab.com"
+content_type: "integration"
+audience: "admin"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: ["GitLab.com"]
+role_required: "Jira Administrator"
+version_required: "all"
+status: "deprecated"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "integration", "admin", "GitLab.com", "deprecated"]
 taxonomy:
     category: git-integration-for-jira-cloud
-
 ---
+<kbd>Last updated: March 2026</kbd>
 
 <div class="bbb-callout bbb--info">
     <div class="irow">
@@ -473,5 +484,3 @@ The merge request is also ready for approval by the reviewers in your GitLab web
 </div>
 
 <p>&nbsp;</p>
-
-<p style="text-align: center; margin: 0; padding: 0;"><kbd>Last updated: December 2025</kbd></p>

--- a/git-integration-for-jira-cloud/gitlab-com-gitlab-ce-ee-jmespath-filter-examples-gij-cloud.md
+++ b/git-integration-for-jira-cloud/gitlab-com-gitlab-ce-ee-jmespath-filter-examples-gij-cloud.md
@@ -1,11 +1,22 @@
 ---
-
-title: GitLab.com | GitLab CE/EE JMESPath filter examples
-description:
+title: "GitLab.com | GitLab CE/EE JMESPath filter examples"
+description: "Step-by-step guide to GitLab.com | GitLab CE/EE JMESPath filter examples in Git Integration for Jira Cloud for GitLab CE/EE, GitLab.com, GitLab, for Jira Cloud users."
+product: "Git Integration for Jira Cloud"
+feature: "GitLab.com | GitLab CE/EE JMESPath filter examples"
+content_type: "integration"
+audience: "all"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: ["GitLab CE/EE", "GitLab.com"]
+role_required: "all"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "integration", "GitLab CE/EE", "GitLab.com"]
 taxonomy:
     category: git-integration-for-jira-cloud
-
 ---
+<kbd>Last updated: March 2026</kbd>
 
 &nbsp;
 
@@ -111,4 +122,3 @@ Lists only repositories from projects that have existing repositories.
 * * *
 
 1 _Logo owned by_ [_GitLab Inc_](https://gitlab.com/) _used under_ [_license_](https://creativecommons.org/licenses/by-nc-sa/4.0/)
-

--- a/git-integration-for-jira-cloud/gitlab-webhook-events-gij-cloud.md
+++ b/git-integration-for-jira-cloud/gitlab-webhook-events-gij-cloud.md
@@ -1,9 +1,22 @@
 ---
-title: GitLab webhook events
-description: Reference documentation for GitLab webhook event types supported by Git Integration for Jira Cloud.
+title: "GitLab webhook events"
+description: "Reference documentation for GitLab webhook event types supported by Git Integration for Jira Cloud."
+product: "Git Integration for Jira Cloud"
+feature: "GitLab webhook events"
+content_type: "reference"
+audience: "all"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: ["GitLab"]
+role_required: "all"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "reference", "GitLab"]
 taxonomy:
     category: git-integration-for-jira-cloud
 ---
+<kbd>Last updated: March 2026</kbd>
 
 This page documents the GitLab webhook event types that Git Integration for Jira Cloud supports.
 
@@ -149,5 +162,3 @@ This page documents the GitLab webhook event types that Git Integration for Jira
 - [Microsoft webhook events](/git-integration-for-jira-cloud/microsoft-webhook-events-gij-cloud)
 - [AWS CodeCommit webhook events](/git-integration-for-jira-cloud/aws-codecommit-webhook-events-gij-cloud)
 - [Bitbucket webhook events](/git-integration-for-jira-cloud/bitbucket-webhook-events-gij-cloud)
-
-<kbd>Last updated: December 2025</kbd>

--- a/git-integration-for-jira-cloud/gitlab-webhook-indexing-integration-gij-cloud.md
+++ b/git-integration-for-jira-cloud/gitlab-webhook-indexing-integration-gij-cloud.md
@@ -1,9 +1,22 @@
 ---
-title: GitLab webhook indexing integration
-description: Configure webhook indexing integration for GitLab.com or GitLab CE/EE to work with Git Integration for Jira Cloud behind firewalls.
+title: "GitLab webhook indexing integration"
+description: "Configure webhook indexing integration for GitLab.com or GitLab CE/EE to work with Git Integration for Jira Cloud behind firewalls."
+product: "Git Integration for Jira Cloud"
+feature: "GitLab webhook indexing integration"
+content_type: "install"
+audience: "admin"
+plan_required: "Standard, Advanced"
+deployment: "Jira Cloud"
+git_host_support: ["GitLab CE/EE", "GitLab.com"]
+role_required: "Jira Administrator"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "install", "admin", "GitLab CE/EE", "GitLab.com", "Standard, Advanced"]
 taxonomy:
     category: git-integration-for-jira-cloud
 ---
+<kbd>Last updated: March 2026</kbd>
 
 <div class="bbb-callout bbb--info">
     <div class="irow">
@@ -192,5 +205,3 @@ For complete feature details, see [Feature matrix](/git-integration-for-jira-clo
 - [GitHub webhook indexing integration](/git-integration-for-jira-cloud/github-webhook-indexing-integration-gij-cloud)
 - [Microsoft webhook indexing integration](/git-integration-for-jira-cloud/microsoft-webhook-indexing-integration-gij-cloud)
 - [Gerrit webhook indexing integration](/git-integration-for-jira-cloud/gerrit-webhook-indexing-integration-gij-cloud)
-
-<kbd>Last updated: December 2025</kbd>

--- a/git-integration-for-jira-cloud/glossary-of-terms-gij-cloud.md
+++ b/git-integration-for-jira-cloud/glossary-of-terms-gij-cloud.md
@@ -1,11 +1,22 @@
 ---
-
-title: Glossary of terms
-description: Definitions of common terms used in Git Integration for Jira documentation
+title: "Glossary of terms"
+description: "Definitions of common terms used in Git Integration for Jira documentation"
+product: "Git Integration for Jira Cloud"
+feature: "Glossary of terms"
+content_type: "install"
+audience: "admin"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "Jira Administrator"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "install", "admin"]
 taxonomy:
     category: git-integration-for-jira-cloud
-
 ---
+<kbd>Last updated: March 2026</kbd>
 
 ### Git
 
@@ -53,5 +64,3 @@ This database stores information about all commits (comment, author, etc.) as we
 [**Next:** Licensing notice](/git-integration-for-jira-cloud/licensing-notice-gij-cloud)
 
 <p>&nbsp;</p>
-
-<p style="text-align: center; margin: 0; padding: 0;"><kbd>Last updated: December 2025</kbd></p>

--- a/git-integration-for-jira-cloud/hooks-and-webhooks-gij-cloud.md
+++ b/git-integration-for-jira-cloud/hooks-and-webhooks-gij-cloud.md
@@ -1,9 +1,22 @@
 ---
-title: Hooks and Webhooks
-description: Configure client-side hooks, server-side hooks, and indexing triggers for Git Integration for Jira Cloud.
+title: "Hooks and Webhooks"
+description: "Configure client-side hooks, server-side hooks, and indexing triggers for Git Integration for Jira Cloud."
+product: "Git Integration for Jira Cloud"
+feature: "Hooks and Webhooks"
+content_type: "concept"
+audience: "all"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "all"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "concept"]
 taxonomy:
     category: git-integration-for-jira-cloud
 ---
+<kbd>Last updated: March 2026</kbd>
 
 This section covers hooks and webhooks supported by Git Integration for Jira Cloud. Use these features to enforce commit policies and enable real-time repository indexing.
 
@@ -22,5 +35,3 @@ Apply project policies using server-side hooks. These scripts run before and aft
 ### [Set Up Indexing Triggers](/git-integration-for-jira-cloud/indexing-triggers-gij-cloud)
 
 Configure webhooks to trigger immediate reindexing of your repositories from remote systems, providing near real-time git data in Jira.
-
-<kbd>Last updated: December 2025</kbd>

--- a/git-integration-for-jira-cloud/how-to-articles-gij-cloud.md
+++ b/git-integration-for-jira-cloud/how-to-articles-gij-cloud.md
@@ -1,9 +1,22 @@
 ---
-title: How-to articles
-description: Browse step-by-step guides for Git Integration for Jira Cloud including pricing, configuration, and integration workflows.
+title: "How-to articles"
+description: "Browse step-by-step guides for Git Integration for Jira Cloud including pricing, configuration, and integration workflows."
+product: "Git Integration for Jira Cloud"
+feature: "How-to articles"
+content_type: "install"
+audience: "reseller"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "reseller"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "install", "reseller"]
 taxonomy:
     category: git-integration-for-jira-cloud
 ---
+<kbd>Last updated: March 2026</kbd>
 
 This collection of how-to guides walks you through common tasks and recommended workflows for Git Integration for Jira Cloud.
 
@@ -44,5 +57,3 @@ This collection of how-to guides walks you through common tasks and recommended 
 ### Indexing and Webhooks
 
 [How to Create Reindex Triggers for a Single Repository](/git-integration-for-jira-cloud/how-to-create-reindex-triggers-for-a-single-repository-gij-cloud) - Set up webhooks for targeted reindexing
-
-<kbd>Last updated: December 2025</kbd>

--- a/git-integration-for-jira-cloud/how-to-calculate-pricing-gij-cloud.md
+++ b/git-integration-for-jira-cloud/how-to-calculate-pricing-gij-cloud.md
@@ -1,9 +1,22 @@
 ---
-title: How to Calculate Pricing
-description: Calculate Git Integration for Jira Cloud pricing using the Atlassian Cloud Pricing Calculator or Marketplace.
+title: "How to Calculate Pricing"
+description: "Calculate Git Integration for Jira Cloud pricing using the Atlassian Cloud Pricing Calculator or Marketplace."
+product: "Git Integration for Jira Cloud"
+feature: "How to Calculate Pricing"
+content_type: "faq"
+audience: "reseller"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "reseller"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "faq", "reseller"]
 taxonomy:
     category: git-integration-for-jira-cloud
 ---
+<kbd>Last updated: March 2026</kbd>
 
 Use one of these four methods to calculate Git Integration for Jira Cloud pricing.
 
@@ -39,5 +52,3 @@ Visit the [Atlassian Marketplace: Git Integration for Jira](https://marketplace.
     </div>
     </div>
 </div>
-
-<kbd>Last updated: December 2025</kbd>

--- a/git-integration-for-jira-cloud/how-to-create-reindex-triggers-for-a-single-repository-gij-cloud.md
+++ b/git-integration-for-jira-cloud/how-to-create-reindex-triggers-for-a-single-repository-gij-cloud.md
@@ -1,9 +1,22 @@
 ---
-title: How to Create Reindex Triggers for a Single Repository
-description: Create webhook triggers to reindex a single repository in Git Integration for Jira Cloud.
+title: "How to Create Reindex Triggers for a Single Repository"
+description: "Create webhook triggers to reindex a single repository in Git Integration for Jira Cloud."
+product: "Git Integration for Jira Cloud"
+feature: "How to Create Reindex Triggers for a Single Repository"
+content_type: "integration"
+audience: "all"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "all"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "integration"]
 taxonomy:
     category: git-integration-for-jira-cloud
 ---
+<kbd>Last updated: March 2026</kbd>
 
 Create a webhook that triggers reindexing for a specific repository by following these requirements.
 
@@ -38,5 +51,3 @@ Replace `https://gitlab.com/your-org/your-repo.git` with your actual repository 
 ## Verify the Result
 
 After sending the webhook request, the repository enters the indexing queue. You can verify this on the **Git** ➜ **Manage git repositories** page.
-
-<kbd>Last updated: December 2025</kbd>

--- a/git-integration-for-jira-cloud/how-to-get-a-quote-gij-cloud.md
+++ b/git-integration-for-jira-cloud/how-to-get-a-quote-gij-cloud.md
@@ -1,9 +1,22 @@
 ---
-title: How to get a quote?
-description: Generate a pricing quote for Git Integration for Jira Cloud through the Atlassian Marketplace.
+title: "How to get a quote?"
+description: "Generate a pricing quote for Git Integration for Jira Cloud through the Atlassian Marketplace."
+product: "Git Integration for Jira Cloud"
+feature: "How to get a quote?"
+content_type: "install"
+audience: "reseller"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "reseller"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "install", "reseller"]
 taxonomy:
     category: git-integration-for-jira-cloud
 ---
+<kbd>Last updated: March 2026</kbd>
 
 Follow these steps to generate a quote for Git Integration for Jira Cloud.
 
@@ -24,5 +37,3 @@ Follow these steps to generate a quote for Git Integration for Jira Cloud.
 ## More Information
 
 For details about licensing, see [Licensing Information, Migration and Transition](/git-integration-for-jira-data-center/licensing-information-migration-and-transition-gij-self-managed).
-
-<kbd>Last updated: December 2025</kbd>

--- a/git-integration-for-jira-cloud/indexing-triggers-formerly-webhooks-gij-cloud.md
+++ b/git-integration-for-jira-cloud/indexing-triggers-formerly-webhooks-gij-cloud.md
@@ -1,9 +1,22 @@
 ---
-title: Indexing triggers (formerly Webhooks)
-description: How to configure indexing triggers for faster repository updates in Git Integration for Jira Cloud.
+title: "Indexing triggers (formerly Webhooks)"
+description: "How to configure indexing triggers for faster repository updates in Git Integration for Jira Cloud."
+product: "Git Integration for Jira Cloud"
+feature: "Indexing triggers (formerly Webhooks)"
+content_type: "install"
+audience: "admin"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "Jira Administrator"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "install", "admin"]
 taxonomy:
     category: git-integration-for-jira-cloud
 ---
+<kbd>Last updated: March 2026</kbd>
 
 Indexing triggers enable immediate reindexing of your repositories from remote systems. When your git data changes, triggers send near real-time data to Jira, eliminating the wait for the regular 5-minute polling interval.
 
@@ -70,5 +83,3 @@ The **Secret Key** is a secure, randomly-generated alphanumeric string created w
 [**Next:** Localization support](/git-integration-for-jira-cloud/localization-support-gij-cloud/)
 
 <p>&nbsp;</p>
-
-<p style="text-align: center; margin: 0; padding: 0;"><kbd>Last updated: December 2025</kbd></p>

--- a/git-integration-for-jira-cloud/indexing-triggers-gij-cloud.md
+++ b/git-integration-for-jira-cloud/indexing-triggers-gij-cloud.md
@@ -1,9 +1,22 @@
 ---
-title: Indexing Triggers
-description: Configure indexing triggers (webhooks) to enable real-time repository updates in Git Integration for Jira Cloud.
+title: "Indexing Triggers"
+description: "Configure indexing triggers (webhooks) to enable real-time repository updates in Git Integration for Jira Cloud."
+product: "Git Integration for Jira Cloud"
+feature: "Indexing Triggers"
+content_type: "integration"
+audience: "developer"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "User"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "integration", "developer"]
 taxonomy:
     category: git-integration-for-jira-cloud
 ---
+<kbd>Last updated: March 2026</kbd>
 
 **On this page:**
 - [Understand indexing triggers](#understand-indexing-triggers)
@@ -174,5 +187,3 @@ This webhook URL triggers events only for a single repository.
     </div>
     </div>
 </div>
-
-<kbd>Last updated: December 2025</kbd>

--- a/git-integration-for-jira-cloud/installation-via-atlassian-marketplace-gij-cloud.md
+++ b/git-integration-for-jira-cloud/installation-via-atlassian-marketplace-gij-cloud.md
@@ -1,11 +1,22 @@
 ---
-
-title: Installation via Atlassian Marketplace
-description: How to install Git Integration for Jira Cloud from the Atlassian Marketplace
+title: "Installation via Atlassian Marketplace"
+description: "How to install Git Integration for Jira Cloud from the Atlassian Marketplace"
+product: "Git Integration for Jira Cloud"
+feature: "Installation via Atlassian Marketplace"
+content_type: "install"
+audience: "admin"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "Jira Administrator"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "install", "admin"]
 taxonomy:
     category: git-integration-for-jira-cloud
-
 ---
+<kbd>Last updated: March 2026</kbd>
 
 1.  Go to the [**Git Integration for Jira**](https://marketplace.atlassian.com/apps/4984/git-integration-for-jira?tab=overview&hosting=cloud) app Atlassian Marketplace page.
 
@@ -45,5 +56,3 @@ taxonomy:
 [**Next:** Working with SSH keys](/git-integration-for-jira-cloud/working-with-ssh-keys-gij-cloud)
 
 <p>&nbsp;</p>
-
-<p style="text-align: center; margin: 0; padding: 0;"><kbd>Last updated: December 2025</kbd></p>

--- a/git-integration-for-jira-cloud/integration-guide-gij-cloud.md
+++ b/git-integration-for-jira-cloud/integration-guide-gij-cloud.md
@@ -1,11 +1,22 @@
 ---
-
-title: Integration Guide
-description: Guide to connecting Git repositories with Jira Cloud using Git Integration for Jira
+title: "Integration Guide"
+description: "Guide to connecting Git repositories with Jira Cloud using Git Integration for Jira"
+product: "Git Integration for Jira Cloud"
+feature: "Integration Guide"
+content_type: "integration"
+audience: "developer"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "User"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "integration", "developer"]
 taxonomy:
     category: git-integration-for-jira-cloud
-
 ---
+<kbd>Last updated: March 2026</kbd>
 
 Welcome to the Git Integration for Jira app reference page index for topics about integration of git repositories with Jira Cloud.
 
@@ -80,5 +91,3 @@ Connect plain git repositories via the Git Integration for Jira app in Jira Clou
 </div>
 
 <p>&nbsp;</p>
-
-<p style="text-align: center; margin: 0; padding: 0;"><kbd>Last updated: December 2025</kbd></p>

--- a/git-integration-for-jira-cloud/introduction-to-git-integration-gij-cloud.md
+++ b/git-integration-for-jira-cloud/introduction-to-git-integration-gij-cloud.md
@@ -1,11 +1,22 @@
 ---
-
-title: Introduction to Git integration
-description: Learn how to integrate Git repositories with Jira Cloud
+title: "Introduction to Git integration"
+description: "Learn how to integrate Git repositories with Jira Cloud"
+product: "Git Integration for Jira Cloud"
+feature: "Introduction to Git integration"
+content_type: "concept"
+audience: "admin"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "Jira Administrator"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "concept", "admin"]
 taxonomy:
     category: git-integration-for-jira-cloud
-
 ---
+<kbd>Last updated: March 2026</kbd>
 
 Learn basic integration for most git hosts by connecting git repositories to Jira Cloud. This page contains information about the different integration types and how to get started.
 
@@ -110,5 +121,3 @@ Connect your git repositories via **Add integration** (_Apps_ ➜ _Git integrati
 [**Next:** Connecting to a Single Git Repository (HTTP/HTTPS)](/git-integration-for-jira-cloud/connecting-to-a-single-git-repository-http-https-gij-cloud)
 
 <p>&nbsp;</p>
-
-<p style="text-align: center; margin: 0; padding: 0;"><kbd>Last updated: December 2025</kbd></p>

--- a/git-integration-for-jira-cloud/issue-git-source-code-panel-gij-cloud.md
+++ b/git-integration-for-jira-cloud/issue-git-source-code-panel-gij-cloud.md
@@ -1,11 +1,22 @@
 ---
-
-title: Issue Git Source Code Panel
-description: Learn how to view commits, branches, pull requests, and tags in the Issue Git Source Code Panel on Jira issues.
+title: "Issue Git Source Code Panel"
+description: "Learn how to view commits, branches, pull requests, and tags in the Issue Git Source Code Panel on Jira issues."
+product: "Git Integration for Jira Cloud"
+feature: "Issue Git Source Code Panel"
+content_type: "concept"
+audience: "admin"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "Jira Administrator"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "concept", "admin"]
 taxonomy:
     category: git-integration-for-jira-cloud
-
 ---
+<kbd>Last updated: March 2026</kbd>
 
 <div class="bbb-callout bbb--note">
     <div class="irow">
@@ -117,5 +128,3 @@ For detailed information about this feature, see [Documentation: Jira Git integr
 - [Git Integration Server/Data Center vs Jira Cloud – Feature Comparison](/git-integration-for-jira-cloud/git-integration-server-data-center-vs-jira-cloud-feature-comparison-gij-cloud/)
 - [Migrating from Jira Server + Data Center to Jira Cloud](/git-integration-for-jira-cloud/migrating-from-jira-server-data-center-to-jira-cloud-gij-cloud/)
 - [User Settings](/git-integration-for-jira-cloud/user-settings-gij-cloud/)
-
-<kbd>Last updated: December 2025</kbd>

--- a/git-integration-for-jira-cloud/jira-development-information-settings-features-gij-cloud.md
+++ b/git-integration-for-jira-cloud/jira-development-information-settings-features-gij-cloud.md
@@ -1,11 +1,22 @@
 ---
-
-title: Jira Development Information settings feature
-description:
+title: "Jira Development Information settings feature"
+description: "Administrative guide for Jira Development Information settings feature in Git Integration for Jira Cloud, for Jira administrators."
+product: "Git Integration for Jira Cloud"
+feature: "Jira Development Information settings feature"
+content_type: "admin"
+audience: "admin"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "Jira Administrator"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "admin"]
 taxonomy:
     category: git-integration-for-jira-cloud
-
 ---
+<kbd>Last updated: March 2026</kbd>
 
 Access this setting on the dashboard menu via Apps ➜ Git Integration: Manage Git repositories ➜ (sidebar) **General settings**. Alternatively, go to dashboard Jira Settings ➜ Apps ➜ (sidebar) **General settings**.
 
@@ -44,4 +55,3 @@ For more information - see our [Smart Commit documentation](/git-integration-fo
 Behind the "Advanced" link is a function button that gives the Jira administrator the ability to clear out all Development Information associated with the Git Integration for Jira app.
 
 Note that this action takes some time to process and Development Information may be visible in places until the process finishes. Expect the process to take up to 1 hour.
-

--- a/git-integration-for-jira-cloud/jira-issue-page-gij-cloud.md
+++ b/git-integration-for-jira-cloud/jira-issue-page-gij-cloud.md
@@ -1,11 +1,22 @@
 ---
-
-title: Jira issue page
-description: Git development information displayed on the Jira issue page
+title: "Jira issue page"
+description: "Git development information displayed on the Jira issue page"
+product: "Git Integration for Jira Cloud"
+feature: "Jira issue page"
+content_type: "concept"
+audience: "developer"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "User"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "concept", "developer"]
 taxonomy:
     category: git-integration-for-jira-cloud
-
 ---
+<kbd>Last updated: March 2026</kbd>
 
 If the Git Integration for Jira app is configured and licensed successfully, new tabs and panels are added to each Jira issue.
 
@@ -435,6 +446,3 @@ A 'next-gen' project can be created in the Projects screen:
 [**Next:** Jira project page](/git-integration-for-jira-cloud/jira-project-page-gij-cloud/)
 
 <p>&nbsp;</p>
-
-<p style="text-align: center; margin: 0; padding: 0;"><kbd>Last updated: December 2025</kbd></p>
-

--- a/git-integration-for-jira-cloud/jira-project-page-gij-cloud.md
+++ b/git-integration-for-jira-cloud/jira-project-page-gij-cloud.md
@@ -1,11 +1,22 @@
 ---
-
-title: Jira project page
-description: How to view Git commits on the Jira project page
+title: "Jira project page"
+description: "How to view Git commits on the Jira project page"
+product: "Git Integration for Jira Cloud"
+feature: "Jira project page"
+content_type: "integration"
+audience: "developer"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "User"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "integration", "developer"]
 taxonomy:
     category: git-integration-for-jira-cloud
-
 ---
+<kbd>Last updated: March 2026</kbd>
 
 The Project page allows you to manage project-related options.
 
@@ -31,5 +42,3 @@ You can view the history of commits within the entire project scope. Select a pr
 [**Next:** Reindexing](/git-integration-for-jira-cloud/reindexing-gij-cloud)
 
 <p>&nbsp;</p>
-
-<p style="text-align: center; margin: 0; padding: 0;"><kbd>Last updated: December 2025</kbd></p>

--- a/git-integration-for-jira-cloud/jira-user-information-card-gij-cloud.md
+++ b/git-integration-for-jira-cloud/jira-user-information-card-gij-cloud.md
@@ -1,11 +1,22 @@
 ---
-
-title: Jira user information card
-description: How to view user information cards in Git Integration for Jira Cloud
+title: "Jira user information card"
+description: "How to view user information cards in Git Integration for Jira Cloud"
+product: "Git Integration for Jira Cloud"
+feature: "Jira user information card"
+content_type: "integration"
+audience: "developer"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "User"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "integration", "developer"]
 taxonomy:
     category: git-integration-for-jira-cloud
-
 ---
+<kbd>Last updated: March 2026</kbd>
 
 The Jira user card is available on the following screens:
 
@@ -38,5 +49,3 @@ Click **View profile** to view this user's profile.
 [**Next:** Jira issue page](/git-integration-for-jira-cloud/jira-issue-page-gij-cloud)
 
 <p>&nbsp;</p>
-
-<p style="text-align: center; margin: 0; padding: 0;"><kbd>Last updated: December 2025</kbd></p>

--- a/git-integration-for-jira-cloud/jql-searching-for-commits-and-pull-requests-gij-cloud.md
+++ b/git-integration-for-jira-cloud/jql-searching-for-commits-and-pull-requests-gij-cloud.md
@@ -1,11 +1,22 @@
 ---
-
-title: JQL Searching for Commits and Pull Requests
-description: Learn how to use JQL syntax to search for Jira issues based on commit and pull request activity.
+title: "JQL Searching for Commits and Pull Requests"
+description: "Learn how to use JQL syntax to search for Jira issues based on commit and pull request activity."
+product: "Git Integration for Jira Cloud"
+feature: "JQL Searching for Commits and Pull Requests"
+content_type: "integration"
+audience: "developer"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "User"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "integration", "developer"]
 taxonomy:
     category: git-integration-for-jira-cloud
-
 ---
+<kbd>Last updated: March 2026</kbd>
 
 <!-- FEATURES -->
 
@@ -89,5 +100,3 @@ development[pullrequests].open > 0
 - **JQL searching for commits and pull requests** (this page)
 - [Jira Cloud Smart Commits and Workflow Triggers](/git-integration-for-jira-cloud/jira-cloud-smart-commits-and-workflow-triggers-gij-cloud/)
 - [Jira Development Information general settings](/git-integration-for-jira-cloud/jira-development-information-settings-gij-cloud)
-
-<kbd>Last updated: December 2025</kbd>

--- a/git-integration-for-jira-cloud/known-issues-gij-cloud.md
+++ b/git-integration-for-jira-cloud/known-issues-gij-cloud.md
@@ -1,9 +1,22 @@
 ---
-title: Known Issues (GIJ Cloud)
-description: Known issues and workarounds for Git Integration for Jira Cloud.
+title: "Known Issues (GIJ Cloud)"
+description: "Known issues and workarounds for Git Integration for Jira Cloud."
+product: "Git Integration for Jira Cloud"
+feature: "Known Issues (GIJ Cloud)"
+content_type: "troubleshooting"
+audience: "developer"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "User"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "troubleshooting", "developer"]
 taxonomy:
     category: git-integration-for-jira-cloud
 ---
+<kbd>Last updated: March 2026</kbd>
 
 This page documents known issues and limitations in Git Integration for Jira Cloud along with available workarounds.
 
@@ -143,5 +156,3 @@ In rare cases, web links for branches and tags do not update automatically after
 2. Re-enable the integration to apply the web linking update.
 
 _Reference: GITCL-3981_
-
-<kbd>Last updated: December 2025</kbd>

--- a/git-integration-for-jira-cloud/known-performance-limitations-gij-cloud.md
+++ b/git-integration-for-jira-cloud/known-performance-limitations-gij-cloud.md
@@ -1,11 +1,22 @@
 ---
-
-title: Known Performance Limitations
-description: Soft limits and performance guidelines for Git Integration for Jira Cloud
+title: "Known Performance Limitations"
+description: "Soft limits and performance guidelines for Git Integration for Jira Cloud"
+product: "Git Integration for Jira Cloud"
+feature: "Known Performance Limitations"
+content_type: "troubleshooting"
+audience: "all"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "all"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "troubleshooting"]
 taxonomy:
     category: git-integration-for-jira-cloud
-
 ---
+<kbd>Last updated: March 2026</kbd>
 
 Git Integration for Jira Cloud runs on AWS instances and has fewer configuration options compared to a self-hosted Jira/GIJ instance. This document details soft limits beyond which some customers experience performance issues.
 
@@ -91,5 +102,3 @@ See [Max Object Error](/git-integration-for-jira-cloud/error-while-reindexing-ja
 | | Long loading times or timeout errors when loading development data |
 
 <p>&nbsp;</p>
-
-<p style="text-align: center; margin: 0; padding: 0;"><kbd>Last updated: December 2025</kbd></p>

--- a/git-integration-for-jira-cloud/licensing-notice-gij-cloud.md
+++ b/git-integration-for-jira-cloud/licensing-notice-gij-cloud.md
@@ -1,11 +1,22 @@
 ---
-
-title: Licensing notice
-description: License information for Git Integration for Jira Cloud
+title: "Licensing notice"
+description: "License information for Git Integration for Jira Cloud"
+product: "Git Integration for Jira Cloud"
+feature: "Licensing notice"
+content_type: "reference"
+audience: "all"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "all"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "reference"]
 taxonomy:
     category: git-integration-for-jira-cloud
-
 ---
+<kbd>Last updated: March 2026</kbd>
 
 The **Git Integration for Jira** app contains some code covered by the following license:
 
@@ -32,5 +43,3 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 [**Back to:** Documentation main index](/git-integration-for-jira-cloud/documentation-gij-cloud)
 
 <p>&nbsp;</p>
-
-<p style="text-align: center; margin: 0; padding: 0;"><kbd>Last updated: December 2025</kbd></p>

--- a/git-integration-for-jira-cloud/linking-git-commits-to-jira-issues-gij-cloud.md
+++ b/git-integration-for-jira-cloud/linking-git-commits-to-jira-issues-gij-cloud.md
@@ -1,9 +1,22 @@
 ---
-title: Linking git commits to Jira issues
-description: How to link Git commits, branches, and pull requests to Jira issues
+title: "Linking git commits to Jira issues"
+description: "How to link Git commits, branches, and pull requests to Jira issues"
+product: "Git Integration for Jira Cloud"
+feature: "Linking git commits to Jira issues"
+content_type: "integration"
+audience: "developer"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "User"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "integration", "developer"]
 taxonomy:
     category: git-integration-for-jira-cloud
 ---
+<kbd>Last updated: March 2026</kbd>
 
 Link your git commits to Jira issues by including the issue key in the commit message.
 
@@ -259,5 +272,3 @@ Include the Jira issue key in the pull request title or description when you cre
 [**Next:** Smart commits](/git-integration-for-jira-cloud/smart-commits-gij-cloud)
 
 <p>&nbsp;</p>
-
-<p style="text-align: center; margin: 0; padding: 0;"><kbd>Last updated: December 2025</kbd></p>

--- a/git-integration-for-jira-cloud/localization-support-gij-cloud.md
+++ b/git-integration-for-jira-cloud/localization-support-gij-cloud.md
@@ -1,11 +1,22 @@
 ---
-
-title: Localization support
-description: Supported languages for Git Integration for Jira Cloud
+title: "Localization support"
+description: "Supported languages for Git Integration for Jira Cloud"
+product: "Git Integration for Jira Cloud"
+feature: "Localization support"
+content_type: "integration"
+audience: "all"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "all"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "integration"]
 taxonomy:
     category: git-integration-for-jira-cloud
-
 ---
+<kbd>Last updated: March 2026</kbd>
 
 Unicode characters are supported and displayed properly.
 
@@ -41,5 +52,3 @@ To switch to another language:
 [**Next:** Glossary of terms](/git-integration-for-jira-cloud/glossary-of-terms-gij-cloud)
 
 <p>&nbsp;</p>
-
-<p style="text-align: center; margin: 0; padding: 0;"><kbd>Last updated: December 2025</kbd></p>

--- a/git-integration-for-jira-cloud/manager-permissions-gij-cloud.md
+++ b/git-integration-for-jira-cloud/manager-permissions-gij-cloud.md
@@ -1,9 +1,22 @@
 ---
-title: Manager permissions
-description: Learn how to configure manager permissions in Git Integration for Jira Cloud to delegate app administration to non-admin users.
+title: "Manager permissions"
+description: "Learn how to configure manager permissions in Git Integration for Jira Cloud to delegate app administration to non-admin users."
+product: "Git Integration for Jira Cloud"
+feature: "Manager permissions"
+content_type: "admin"
+audience: "admin"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "Jira Administrator"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "admin"]
 taxonomy:
     category: git-integration-for-jira-cloud
 ---
+<kbd>Last updated: March 2026</kbd>
 
 Manager permissions allow Jira administrators to delegate Git Integration for Jira app management to non-admin users. Designated users can manage integrations, add or remove repositories, and update settings without requiring full Jira admin access.
 
@@ -125,5 +138,3 @@ Non-admin users who are not in the GIJ Managers group cannot see or access:
 
 - Git Integration for Jira app configuration
 - Manager permissions pages
-
-<kbd>Last updated: December 2025</kbd>

--- a/git-integration-for-jira-cloud/managing-integration-or-repository-configuration-gij-cloud.md
+++ b/git-integration-for-jira-cloud/managing-integration-or-repository-configuration-gij-cloud.md
@@ -1,11 +1,22 @@
 ---
-
-title: Managing integration or repository configuration
-description: How to manage Git integrations and repositories in Jira Cloud
+title: "Managing integration or repository configuration"
+description: "How to manage Git integrations and repositories in Jira Cloud"
+product: "Git Integration for Jira Cloud"
+feature: "Managing integration or repository configuration"
+content_type: "integration"
+audience: "admin"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "Jira Administrator"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "integration", "admin"]
 taxonomy:
     category: git-integration-for-jira-cloud
-
 ---
+<kbd>Last updated: March 2026</kbd>
 
 After successfully integrating a git host service or connecting git repositories via Git Integration for Jira, you can modify integration or repository settings depending on the connection protocol.
 
@@ -63,5 +74,3 @@ Manage connected integrations or repositories using the <img src='/wp-content/up
 [**Next:** Managing integrations via Actions (Jira Cloud)](/git-integration-for-jira-cloud/managing-integrations-via-actions-jira-cloud-gij-cloud/)
 
 <p>&nbsp;</p>
-
-<p style="text-align: center; margin: 0; padding: 0;"><kbd>Last updated: December 2025</kbd></p>

--- a/git-integration-for-jira-cloud/managing-integrations-via-actions-jira-cloud-gij-cloud.md
+++ b/git-integration-for-jira-cloud/managing-integrations-via-actions-jira-cloud-gij-cloud.md
@@ -1,11 +1,22 @@
 ---
-
-title: Managing integrations via Actions (Jira Cloud)
-description: How to use Actions to manage Git integrations and repositories
+title: "Managing integrations via Actions (Jira Cloud)"
+description: "How to use Actions to manage Git integrations and repositories"
+product: "Git Integration for Jira Cloud"
+feature: "Managing integrations via Actions (Jira Cloud)"
+content_type: "integration"
+audience: "admin"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "Jira Administrator"
+version_required: "all"
+status: "deprecated"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "integration", "admin", "deprecated"]
 taxonomy:
     category: git-integration-for-jira-cloud
-
 ---
+<kbd>Last updated: March 2026</kbd>
 
 After integrating your repository or git host service, you can perform a set of Actions by clicking the Gear icon under the **Actions** column on the integration/repository configuration list.
 
@@ -110,5 +121,3 @@ Group action becomes available when selecting multiple integrations and reposito
 [Associating project permissions](/git-integration-for-jira-cloud/associating-project-permissions-gij-cloud/) (Git Integration for Jira Cloud)
 
 <p>&nbsp;</p>
-
-<p style="text-align: center; margin: 0; padding: 0;"><kbd>Last updated: December 2025</kbd></p>

--- a/git-integration-for-jira-cloud/manually-connect-to-https-git-repositories-with-self-signed-ssl-certificates-or-other-ssl-issues-gij-cloud.md
+++ b/git-integration-for-jira-cloud/manually-connect-to-https-git-repositories-with-self-signed-ssl-certificates-or-other-ssl-issues-gij-cloud.md
@@ -1,11 +1,22 @@
 ---
-
-title: Manually connect to HTTPS git repositories with self-signed SSL certificates or other SSL issues
-description: How to manually set up git repository connections with self-signed SSL certificates
+title: "Manually connect to HTTPS git repositories with self-signed SSL certificates or other SSL issues"
+description: "How to manually set up git repository connections with self-signed SSL certificates"
+product: "Git Integration for Jira Cloud"
+feature: "Manually connect to HTTPS git repositories with self-signed SSL certificates or other SSL issues"
+content_type: "troubleshooting"
+audience: "admin"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "Jira Administrator"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "troubleshooting", "admin"]
 taxonomy:
     category: git-integration-for-jira-cloud
-
 ---
+<kbd>Last updated: March 2026</kbd>
 
 <b style='background-color:#EAE5FE; padding:1px 5px; color:#412C92; border-radius:3px; margin: 0 5px; font-size: small;'>GITHUB ENTERPRISE</b> <b style='background-color:#FFE3B2; padding:1px 5px; color:#A35F00; border-radius:3px; margin: 0 5px; font-size: small;'>GITLAB CE/EE</b>
 
@@ -54,5 +65,3 @@ For related topics on connecting repositories from other git hosts, see [Integra
 [**Next:** Managing repository or integration configuration](/git-integration-for-jira-cloud/managing-integration-or-repository-configuration-gij-cloud)
 
 <p>&nbsp;</p>
-
-<p style="text-align: center; margin: 0; padding: 0;"><kbd>Last updated: December 2025</kbd></p>

--- a/git-integration-for-jira-cloud/microsoft-vsts-tfs-azure-repos-jmespath-filter-examples-gij-cloud.md
+++ b/git-integration-for-jira-cloud/microsoft-vsts-tfs-azure-repos-jmespath-filter-examples-gij-cloud.md
@@ -1,11 +1,22 @@
 ---
-
-title: Microsoft | VSTS | TFS | Azure Repos JMESPath filter examples
-description:
+title: "Microsoft | VSTS | TFS | Azure Repos JMESPath filter examples"
+description: "Step-by-step guide to Microsoft | VSTS | TFS | Azure Repos JMESPath filter examples in Git Integration for Jira Cloud for Azure DevOps Server, Azure DevOps, for Jira Cloud users."
+product: "Git Integration for Jira Cloud"
+feature: "Microsoft | VSTS | TFS | Azure Repos JMESPath filter examples"
+content_type: "integration"
+audience: "all"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: ["Azure DevOps Server"]
+role_required: "all"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "integration", "Azure DevOps Server"]
 taxonomy:
     category: git-integration-for-jira-cloud
-
 ---
+<kbd>Last updated: March 2026</kbd>
 
 &nbsp;
 
@@ -66,4 +77,3 @@ Lists repositories with names that starts with `'git'` or ends with `'test'`.
 *   **Microsoft \| VSTS \| TFS \| Azure Repos JMESPath filter examples** (this page)
 
 *   [Bitbucket JMESPath filter examples](/git-integration-for-jira-cloud/bitbucket-jmespath-filter-examples-gij-cloud)
-

--- a/git-integration-for-jira-cloud/microsoft-webhook-events-gij-cloud.md
+++ b/git-integration-for-jira-cloud/microsoft-webhook-events-gij-cloud.md
@@ -1,9 +1,22 @@
 ---
-title: Microsoft webhook events
-description: Reference documentation for Microsoft (Azure DevOps/VSTS/TFS) webhook event types supported by Git Integration for Jira Cloud.
+title: "Microsoft webhook events"
+description: "Reference documentation for Microsoft (Azure DevOps/VSTS/TFS) webhook event types supported by Git Integration for Jira Cloud."
+product: "Git Integration for Jira Cloud"
+feature: "Microsoft webhook events"
+content_type: "reference"
+audience: "developer"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: ["Azure DevOps Server"]
+role_required: "User"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "reference", "developer", "Azure DevOps Server"]
 taxonomy:
     category: git-integration-for-jira-cloud
 ---
+<kbd>Last updated: March 2026</kbd>
 
 This page documents the Microsoft webhook event types that Git Integration for Jira Cloud supports.
 
@@ -115,5 +128,3 @@ This page documents the Microsoft webhook event types that Git Integration for J
 - [GitLab webhook events](/git-integration-for-jira-cloud/gitlab-webhook-events-gij-cloud)
 - [AWS CodeCommit webhook events](/git-integration-for-jira-cloud/aws-codecommit-webhook-events-gij-cloud)
 - [Bitbucket webhook events](/git-integration-for-jira-cloud/bitbucket-webhook-events-gij-cloud)
-
-<kbd>Last updated: December 2025</kbd>

--- a/git-integration-for-jira-cloud/microsoft-webhook-indexing-integration-gij-cloud.md
+++ b/git-integration-for-jira-cloud/microsoft-webhook-indexing-integration-gij-cloud.md
@@ -1,9 +1,22 @@
 ---
-title: Microsoft webhook indexing integration
-description: Configure webhook indexing integration for Azure DevOps, Azure Repos, VSTS, or TFS to work with Git Integration for Jira Cloud behind firewalls.
+title: "Microsoft webhook indexing integration"
+description: "Configure webhook indexing integration for Azure DevOps, Azure Repos, VSTS, or TFS to work with Git Integration for Jira Cloud behind firewalls."
+product: "Git Integration for Jira Cloud"
+feature: "Microsoft webhook indexing integration"
+content_type: "install"
+audience: "admin"
+plan_required: "Standard, Advanced"
+deployment: "Jira Cloud"
+git_host_support: ["Azure DevOps Server"]
+role_required: "Jira Administrator"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "install", "admin", "Azure DevOps Server", "Standard, Advanced"]
 taxonomy:
     category: git-integration-for-jira-cloud
 ---
+<kbd>Last updated: March 2026</kbd>
 
 <div class="bbb-callout bbb--info">
     <div class="irow">
@@ -198,5 +211,3 @@ For complete feature details, see [Feature matrix](/git-integration-for-jira-clo
 - [GitHub webhook indexing integration](/git-integration-for-jira-cloud/github-webhook-indexing-integration-gij-cloud)
 - [GitLab webhook indexing integration](/git-integration-for-jira-cloud/gitlab-webhook-indexing-integration-gij-cloud)
 - [Gerrit webhook indexing integration](/git-integration-for-jira-cloud/gerrit-webhook-indexing-integration-gij-cloud)
-
-<kbd>Last updated: December 2025</kbd>

--- a/git-integration-for-jira-cloud/migrating-from-jira-server-data-center-to-jira-cloud-gij-cloud.md
+++ b/git-integration-for-jira-cloud/migrating-from-jira-server-data-center-to-jira-cloud-gij-cloud.md
@@ -1,11 +1,22 @@
 ---
-
-title: Migrating from Jira Server + Data Center to Jira Cloud
-description: Step-by-step guide for migrating Git Integration for Jira from Server or Data Center to Jira Cloud.
+title: "Migrating from Jira Server + Data Center to Jira Cloud"
+description: "Step-by-step guide for migrating Git Integration for Jira from Server or Data Center to Jira Cloud."
+product: "Git Integration for Jira Cloud"
+feature: "Migrating from Jira Server + Data Center to Jira Cloud"
+content_type: "integration"
+audience: "admin"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "Jira Administrator"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "integration", "admin"]
 taxonomy:
     category: git-integration-for-jira-cloud
-
 ---
+<kbd>Last updated: March 2026</kbd>
 
 **What’s on this page:**
 - [Let us assist you with your migration to Jira Cloud!](#let-us-assist-you)
@@ -124,6 +135,3 @@ Currently there are not automatic steps to migrate from Jira Server + Data Cente
 &nbsp;
 
 <br>
-
-<kbd>Last updated: December 2025</kbd>
-

--- a/git-integration-for-jira-cloud/nested-repository-gij-cloud.md
+++ b/git-integration-for-jira-cloud/nested-repository-gij-cloud.md
@@ -1,11 +1,22 @@
 ---
-
-title: Nested repository
-description: Understanding and configuring nested repositories in Git Integration for Jira Cloud
+title: "Nested repository"
+description: "Understanding and configuring nested repositories in Git Integration for Jira Cloud"
+product: "Git Integration for Jira Cloud"
+feature: "Nested repository"
+content_type: "integration"
+audience: "all"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "all"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "integration"]
 taxonomy:
     category: git-integration-for-jira-cloud
-
 ---
+<kbd>Last updated: March 2026</kbd>
 
 A nested repository is a Git repository that exists inside the working directory of another Git repository. In other words, it's a repository within a repository. Each nested repository functions independently, with its own commit history, branches, and remote configurations.
 
@@ -214,5 +225,3 @@ To view the nested repository settings, go to the Manage repositories page and n
 [**Next:** Self-signed HTTPS integration](/git-integration-for-jira-cloud/self-signed-https-integration-gij-cloud)
 
 <p>&nbsp;</p>
-
-<p style="text-align: center; margin: 0; padding: 0;"><kbd>Last updated: December 2025</kbd></p>

--- a/git-integration-for-jira-cloud/permissions-gij-cloud.md
+++ b/git-integration-for-jira-cloud/permissions-gij-cloud.md
@@ -1,11 +1,22 @@
 ---
-
-title: Permissions
-description: Permission requirements for viewing commit information and Git data in Jira
+title: "Permissions"
+description: "Permission requirements for viewing commit information and Git data in Jira"
+product: "Git Integration for Jira Cloud"
+feature: "Permissions"
+content_type: "integration"
+audience: "admin"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "Jira Administrator"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "integration", "admin"]
 taxonomy:
     category: git-integration-for-jira-cloud
-
 ---
+<kbd>Last updated: March 2026</kbd>
 
 ## Permissions Required to View Commit Information
 
@@ -32,5 +43,3 @@ When setting permissions, keep the following in mind:
 - The default permission scheme grants access to the app for all members of the **administrators** and **developers** groups. No additional configuration is required in this case.
 
 <p>&nbsp;</p>
-
-<p style="text-align: center; margin: 0; padding: 0;"><kbd>Last updated: December 2025</kbd></p>

--- a/git-integration-for-jira-cloud/personal-access-token-feature-gij-cloud.md
+++ b/git-integration-for-jira-cloud/personal-access-token-feature-gij-cloud.md
@@ -1,11 +1,22 @@
 ---
-
-title: Personal access token feature
-description: Learn how to configure personal access tokens for git integrations in Git Integration for Jira Cloud.
+title: "Personal access token feature"
+description: "Learn how to configure personal access tokens for git integrations in Git Integration for Jira Cloud."
+product: "Git Integration for Jira Cloud"
+feature: "Personal access token feature"
+content_type: "security"
+audience: "all"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "all"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "security"]
 taxonomy:
     category: git-integration-for-jira-cloud
-
 ---
+<kbd>Last updated: March 2026</kbd>
 
 <!-- USER SETTINGS -->
 
@@ -43,5 +54,3 @@ Click **New token** to generate a new personal access token through the git serv
 [**Prev:** Default repository feature](/git-integration-for-jira-cloud/default-repository-feature-gij-cloud)
 
 [**Back to:** User settings (index)](/git-integration-for-jira-cloud/user-settings-gij-cloud)
-
-<kbd>Last updated: December 2025</kbd>

--- a/git-integration-for-jira-cloud/productivity-guide-gij-cloud.md
+++ b/git-integration-for-jira-cloud/productivity-guide-gij-cloud.md
@@ -1,9 +1,22 @@
 ---
-title: Productivity guide
-description: Configure indexing triggers and Automation for Jira to streamline your Git workflows.
+title: "Productivity guide"
+description: "Configure indexing triggers and Automation for Jira to streamline your Git workflows."
+product: "Git Integration for Jira Cloud"
+feature: "Productivity guide"
+content_type: "integration"
+audience: "admin"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "Jira Administrator"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "integration", "admin"]
 taxonomy:
     category: git-integration-for-jira-cloud
 ---
+<kbd>Last updated: March 2026</kbd>
 
 This guide helps you configure indexing and automation triggers to maximize productivity with Git Integration for Jira.
 
@@ -26,5 +39,3 @@ Automate your workflows by connecting Git events to Jira actions. See [Git Integ
 - [Initial setup guide](/git-integration-for-jira-cloud/initial-setup-guide-gij-cloud)
 - [Permissions](/git-integration-for-jira-cloud/permissions-gij-cloud)
 - [Productivity guide](/git-integration-for-jira-cloud/productivity-guide-gij-cloud)
-
-<kbd>Last updated: December 2025</kbd>

--- a/git-integration-for-jira-cloud/pull-request-timeline-for-Signals-gij-cloud.md
+++ b/git-integration-for-jira-cloud/pull-request-timeline-for-Signals-gij-cloud.md
@@ -1,11 +1,22 @@
 ---
-
-title: Pull Request timeline for Signals
-description: Learn about pull request timeline reindexing and permission requirements for GitHub and GitLab integrations with Signals.
+title: "Pull Request timeline for Signals"
+description: "Learn about pull request timeline reindexing and permission requirements for GitHub and GitLab integrations with Signals."
+product: "Git Integration for Jira Cloud"
+feature: "Pull Request timeline for Signals"
+content_type: "install"
+audience: "admin"
+plan_required: "Advanced"
+deployment: "Jira Cloud"
+git_host_support: ["GitHub", "GitLab"]
+role_required: "Jira Administrator"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "install", "admin", "GitHub", "GitLab", "Advanced"]
 taxonomy:
     category: git-integration-for-jira-cloud
-
 ---
+<kbd>Last updated: March 2026</kbd>
 
 <div class="bbb-callout bbb--tip">
     <div class="irow">
@@ -87,5 +98,3 @@ When configuring a GitHub App integration, set these required scopes:
 [Backlog View](/git-integration-for-jira-cloud/Signals-backlog-view-gij-cloud)
 
 <p>&nbsp;</p>
-
-<p style="text-align: center; margin: 0; padding: 0;"><kbd>Last updated: December 2025</kbd></p>

--- a/git-integration-for-jira-cloud/reindexing-gij-cloud.md
+++ b/git-integration-for-jira-cloud/reindexing-gij-cloud.md
@@ -1,11 +1,22 @@
 ---
-
-title: Reindexing
-description: How to manually reindex repositories in Git Integration for Jira Cloud
+title: "Reindexing"
+description: "How to manually reindex repositories in Git Integration for Jira Cloud"
+product: "Git Integration for Jira Cloud"
+feature: "Reindexing"
+content_type: "install"
+audience: "admin"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "Jira Administrator"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "install", "admin"]
 taxonomy:
     category: git-integration-for-jira-cloud
-
 ---
+<kbd>Last updated: March 2026</kbd>
 
 <div class="bbb-callout bbb--alert">
     <div class="irow">
@@ -69,5 +80,3 @@ The indexer shows an error message on the Jira issue ➜ Git Commits tab if inde
 [**Next:** Indexing triggers (formerly Webhooks)](/git-integration-for-jira-cloud/indexing-triggers-gij-cloud)
 
 <p>&nbsp;</p>
-
-<p style="text-align: center; margin: 0; padding: 0;"><kbd>Last updated: December 2025</kbd></p>

--- a/git-integration-for-jira-cloud/removing-integration-or-repository-configuration-gij-cloud.md
+++ b/git-integration-for-jira-cloud/removing-integration-or-repository-configuration-gij-cloud.md
@@ -1,11 +1,22 @@
 ---
-
-title: Disconnecting integrations or repositories
-description: How to disconnect and remove integrations or repositories from Git Integration for Jira Cloud
+title: "Disconnecting integrations or repositories"
+description: "How to disconnect and remove integrations or repositories from Git Integration for Jira Cloud"
+product: "Git Integration for Jira Cloud"
+feature: "Disconnecting integrations or repositories"
+content_type: "integration"
+audience: "admin"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "Jira Administrator"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "integration", "admin"]
 taxonomy:
     category: git-integration-for-jira-cloud
-
 ---
+<kbd>Last updated: March 2026</kbd>
 
 Disconnect a repository or integration if it isn't needed or is broken in the Git Integration for Jira app configuration list.
 
@@ -100,5 +111,3 @@ Go to the **Manage integrations** configuration page and choose a plain git inte
 [Associating project permissions](/git-integration-for-jira-cloud/associating-project-permissions-gij-cloud/) (Git Integration for Jira Cloud)
 
 <p>&nbsp;</p>
-
-<p style="text-align: center; margin: 0; padding: 0;"><kbd>Last updated: December 2025</kbd></p>

--- a/git-integration-for-jira-cloud/repository-browser-gij-cloud.md
+++ b/git-integration-for-jira-cloud/repository-browser-gij-cloud.md
@@ -1,11 +1,22 @@
 ---
-
-title: Repository browser
-description: View and browse Git repositories in Jira Cloud using the Repository browser
+title: "Repository browser"
+description: "View and browse Git repositories in Jira Cloud using the Repository browser"
+product: "Git Integration for Jira Cloud"
+feature: "Repository browser"
+content_type: "integration"
+audience: "admin"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "Jira Administrator"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "integration", "admin"]
 taxonomy:
     category: git-integration-for-jira-cloud
-
 ---
+<kbd>Last updated: March 2026</kbd>
 
 The **Repository Browser** allows users to view git repositories of configured projects via the **Git** menu on the Jira dashboard.
 
@@ -188,5 +199,3 @@ On the **Issues** page, clicking the **View in issue navigator** label opens the
 [**Next:** Viewing commit code diffs](/git-integration-for-jira-cloud/viewing-commit-code-diffs-gij-cloud)
 
 <p>&nbsp;</p>
-
-<p style="text-align: center; margin: 0; padding: 0;"><kbd>Last updated: December 2025</kbd></p>

--- a/git-integration-for-jira-cloud/require-personal-access-tokens-for-user-actions-create-branch-pull-request-gij-cloud.md
+++ b/git-integration-for-jira-cloud/require-personal-access-tokens-for-user-actions-create-branch-pull-request-gij-cloud.md
@@ -1,9 +1,22 @@
 ---
-title: Require Personal Access Tokens for user actions (create branch/pull request)
-description: Configure Git Integration for Jira Cloud to require personal access tokens for user actions like creating branches and pull requests.
+title: "Require Personal Access Tokens for user actions (create branch/pull request)"
+description: "Configure Git Integration for Jira Cloud to require personal access tokens for user actions like creating branches and pull requests."
+product: "Git Integration for Jira Cloud"
+feature: "Require Personal Access Tokens for user actions (create branch/pull request)"
+content_type: "security"
+audience: "admin"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "Jira Administrator"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "security", "admin"]
 taxonomy:
     category: git-integration-for-jira-cloud
 ---
+<kbd>Last updated: March 2026</kbd>
 
 **On this page:**
 - [Understand user attribution](#understand-user-attribution)
@@ -104,5 +117,3 @@ User attribution with personal access tokens works with these integrations:
     <sup>1</sup> <i>Logo owned by <a href='https://gitlab.com/'>GitLab Inc</a> used under <a href='https://creativecommons.org/licenses/by-nc-sa/4.0/'>license</a>.
     <p>&nbsp;&nbsp;All product names, logos, and brands are property of their respective owners.<p><i>
 </div>
-
-<kbd>Last updated: December 2025</kbd>

--- a/git-integration-for-jira-cloud/self-signed-https-integration-gij-cloud.md
+++ b/git-integration-for-jira-cloud/self-signed-https-integration-gij-cloud.md
@@ -1,11 +1,22 @@
 ---
-
-title: Self-signed HTTPS integration
-description: How to integrate repositories using self-signed HTTPS certificates
+title: "Self-signed HTTPS integration"
+description: "How to integrate repositories using self-signed HTTPS certificates"
+product: "Git Integration for Jira Cloud"
+feature: "Self-signed HTTPS integration"
+content_type: "security"
+audience: "admin"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "Jira Administrator"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "security", "admin"]
 taxonomy:
     category: git-integration-for-jira-cloud
-
 ---
+<kbd>Last updated: March 2026</kbd>
 
 Self-signed certificates are common in HTTPS Git repositories that are hosted privately. Even for an administrator, setting the HTTP `sslVerify` option to connect to this repository can be challenging.
 
@@ -32,5 +43,3 @@ Continue to the next topic for further information on setup and integration.
 [**Next:** Automatically connect to HTTPS git repositories with self-signed SSL certificates or other SSL issues](/git-integration-for-jira-cloud/automatically-connect-to-https-git-repositories-with-self-signed-ssl-certificates-or-other-ssl-issues-gij-cloud)
 
 <p>&nbsp;</p>
-
-<p style="text-align: center; margin: 0; padding: 0;"><kbd>Last updated: December 2025</kbd></p>

--- a/git-integration-for-jira-cloud/server-side-hook-gij-cloud.md
+++ b/git-integration-for-jira-cloud/server-side-hook-gij-cloud.md
@@ -1,9 +1,22 @@
 ---
-title: Server-side Hook
-description: Configure server-side hooks to enforce Jira ticket policies on git pushes.
+title: "Server-side Hook"
+description: "Configure server-side hooks to enforce Jira ticket policies on git pushes."
+product: "Git Integration for Jira Cloud"
+feature: "Server-side Hook"
+content_type: "install"
+audience: "admin"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "Jira Administrator"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "install", "admin"]
 taxonomy:
     category: git-integration-for-jira-cloud
 ---
+<kbd>Last updated: March 2026</kbd>
 
 Server-side hooks enforce project policies by running scripts before and after pushes. Use these hooks to require valid Jira ticket references in commit messages.
 
@@ -193,5 +206,3 @@ for c, msg in commits.iteritems():
         print >> sys.stderr, 'Install pre-commit hook (https://bigbrassband.com/api-doc.html#cmhook) to run this check at the commit time'
         sys.exit(1)
 ```
-
-<kbd>Last updated: December 2025</kbd>

--- a/git-integration-for-jira-cloud/setting-project-permissions-gij-cloud.md
+++ b/git-integration-for-jira-cloud/setting-project-permissions-gij-cloud.md
@@ -1,9 +1,22 @@
 ---
-title: Setting Project Permissions
-description: Configure project permissions to control which Jira projects can access Git integration data and repository content.
+title: "Setting Project Permissions"
+description: "Configure project permissions to control which Jira projects can access Git integration data and repository content."
+product: "Git Integration for Jira Cloud"
+feature: "Setting Project Permissions"
+content_type: "concept"
+audience: "admin"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "Jira Administrator"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "concept", "admin"]
 taxonomy:
     category: git-integration-for-jira-cloud
 ---
+<kbd>Last updated: March 2026</kbd>
 
 **On this page:**
 - [Understand project permissions](#understand-project-permissions)
@@ -78,5 +91,3 @@ Limit which Jira projects can access a specific repository:
 5. Select one or more Jira projects from the list.
 
 6. Click **Update** to save your changes.
-
-<kbd>Last updated: December 2025</kbd>

--- a/git-integration-for-jira-cloud/setting-up-integrations-gij-cloud.md
+++ b/git-integration-for-jira-cloud/setting-up-integrations-gij-cloud.md
@@ -1,11 +1,22 @@
 ---
-
-title: Setting up integrations
-description: How to set up and manage Git repository integrations in Jira Cloud
+title: "Setting up integrations"
+description: "How to set up and manage Git repository integrations in Jira Cloud"
+product: "Git Integration for Jira Cloud"
+feature: "Setting up integrations"
+content_type: "concept"
+audience: "admin"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "Jira Administrator"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "concept", "admin"]
 taxonomy:
     category: git-integration-for-jira-cloud
-
 ---
+<kbd>Last updated: March 2026</kbd>
 
 Set up repositories and manage them in the Git Integration app configuration in Jira.
 
@@ -234,5 +245,3 @@ The rest of the features can also be accessed on the left sidebar of the Manage 
 [**Next:** Using the Git service integration wizard](/git-integration-for-jira-cloud/using-the-git-service-integration-wizard-gij-cloud/)
 
 <p>&nbsp;</p>
-
-<p style="text-align: center; margin: 0; padding: 0;"><kbd>Last updated: December 2025</kbd></p>

--- a/git-integration-for-jira-cloud/setup-gitlab-server-to-respond-to-incoming-network-api-calls-gij-cloud.md
+++ b/git-integration-for-jira-cloud/setup-gitlab-server-to-respond-to-incoming-network-api-calls-gij-cloud.md
@@ -1,11 +1,23 @@
 ---
-
-title: Setup GitLab Server to respond to incoming network API calls
-description:
+title: "Setup GitLab Server to respond to incoming network API calls"
+description: "Security and access guide for Setup GitLab Server to respond to incoming network API calls in Git Integration for Jira Cloud for GitLab, for Jira Cloud users."
+product: "Git Integration for Jira Cloud"
+feature: "Setup GitLab Server to respond to incoming network API calls"
+content_type: "integration"
+audience: "all"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: ["GitLab"]
+role_required: "all"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "integration", "GitLab"]
 taxonomy:
     category: git-integration-for-jira-cloud
-
 ---
+<kbd>Last updated: March 2026</kbd>
+
 In order for GitLab to display correct repository clone links to your users, it needs to know the URL under which it is reached by your users (e.g. `http://gitlab.example.com`)
 
 To reconfigure:

--- a/git-integration-for-jira-cloud/smart-commits-gij-cloud.md
+++ b/git-integration-for-jira-cloud/smart-commits-gij-cloud.md
@@ -1,11 +1,22 @@
 ---
-
-title: Smart commits
-description: Use Smart commits to perform actions on Jira issues directly from Git commit messages
+title: "Smart commits"
+description: "Use Smart commits to perform actions on Jira issues directly from Git commit messages"
+product: "Git Integration for Jira Cloud"
+feature: "Smart commits"
+content_type: "concept"
+audience: "developer"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "User"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "concept", "developer"]
 taxonomy:
     category: git-integration-for-jira-cloud
-
 ---
+<kbd>Last updated: March 2026</kbd>
 
 Smart commits allow your team to perform actions on Jira issues from a single commit. Users can enter the issue key and the desired action such as time tracking or closing an issue.
 
@@ -618,5 +629,3 @@ _The above example moves the stage of the Jira issue to CLOSED._
 [**Next:** Repository Browser](/git-integration-for-jira-cloud/repository-browser-gij-cloud)
 
 <p>&nbsp;</p>
-
-<p style="text-align: center; margin: 0; padding: 0;"><kbd>Last updated: December 2025</kbd></p>

--- a/git-integration-for-jira-cloud/ssl-verify-gij-cloud.md
+++ b/git-integration-for-jira-cloud/ssl-verify-gij-cloud.md
@@ -1,11 +1,22 @@
 ---
-
-title: SSL verify
-description: How to configure SSL verification for Git integrations
+title: "SSL verify"
+description: "How to configure SSL verification for Git integrations"
+product: "Git Integration for Jira Cloud"
+feature: "SSL verify"
+content_type: "security"
+audience: "all"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "all"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "security"]
 taxonomy:
     category: git-integration-for-jira-cloud
-
 ---
+<kbd>Last updated: March 2026</kbd>
 
 Access this feature at the following locations on the Manage Git repositories page:
 
@@ -83,5 +94,3 @@ The **SSL Verify** option is set to `Enabled` by default. If set to `Disabled`, 
 [Associating project permissions](/git-integration-for-jira-cloud/associating-project-permissions-gij-cloud/) (Git Integration for Jira Cloud)
 
 <p>&nbsp;</p>
-
-<p style="text-align: center; margin: 0; padding: 0;"><kbd>Last updated: December 2025</kbd></p>

--- a/git-integration-for-jira-cloud/troubleshooting-articles-gij-cloud.md
+++ b/git-integration-for-jira-cloud/troubleshooting-articles-gij-cloud.md
@@ -1,9 +1,22 @@
 ---
-title: Troubleshooting articles
-description: Solutions and workarounds for common issues with Git Integration for Jira Cloud.
+title: "Troubleshooting articles"
+description: "Solutions and workarounds for common issues with Git Integration for Jira Cloud."
+product: "Git Integration for Jira Cloud"
+feature: "Troubleshooting articles"
+content_type: "troubleshooting"
+audience: "admin"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "Jira Administrator"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "troubleshooting", "admin"]
 taxonomy:
     category: git-integration-for-jira-cloud
 ---
+<kbd>Last updated: March 2026</kbd>
 
 This collection of troubleshooting guides provides workarounds and solutions for common issues with Git Integration for Jira Cloud.
 
@@ -396,5 +409,3 @@ Microsoft OAuth app client secrets expire after 5 years. All customers must reco
     </div>
     </div>
 </div>
-
-<kbd>Last updated: December 2025</kbd>

--- a/git-integration-for-jira-cloud/trusted-users-gij-cloud.md
+++ b/git-integration-for-jira-cloud/trusted-users-gij-cloud.md
@@ -1,9 +1,22 @@
 ---
-title: Trusted Users
-description: Learn how to assign the Trusted role to users for Git Integration for Jira Cloud administrative access.
+title: "Trusted Users"
+description: "Learn how to assign the Trusted role to users for Git Integration for Jira Cloud administrative access."
+product: "Git Integration for Jira Cloud"
+feature: "Trusted Users"
+content_type: "security"
+audience: "admin"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "Jira Administrator"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "security", "admin"]
 taxonomy:
     category: git-integration-for-jira-cloud
 ---
+<kbd>Last updated: March 2026</kbd>
 
 Trusted users have administrative permissions for the Git Integration for Jira app. They can see all pages of the app and invite other users.
 
@@ -65,5 +78,3 @@ Jira administrators can grant the Trusted role when inviting users and can chang
 5. Select the new role from the dropdown options.
 
 6. The role change takes effect immediately.
-
-<kbd>Last updated: December 2025</kbd>

--- a/git-integration-for-jira-cloud/user-settings-gij-cloud.md
+++ b/git-integration-for-jira-cloud/user-settings-gij-cloud.md
@@ -1,11 +1,22 @@
 ---
-
-title: User Settings
-description: Configure default repositories, default branches, connected apps, and personal access tokens in Git Integration for Jira Cloud user settings.
+title: "User Settings"
+description: "Configure default repositories, default branches, connected apps, and personal access tokens in Git Integration for Jira Cloud user settings."
+product: "Git Integration for Jira Cloud"
+feature: "User Settings"
+content_type: "security"
+audience: "developer"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "User"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "security", "developer"]
 taxonomy:
     category: git-integration-for-jira-cloud
-
 ---
+<kbd>Last updated: March 2026</kbd>
 
 The User Settings page allows users to set a default repository for the selected Jira project and configure a personal access token for a specific git integration.
 
@@ -29,5 +40,3 @@ To learn more about these features such as default repository and setting up PAT
 - [Default branch feature](/git-integration-for-jira-cloud/default-branch-feature-gij-cloud/)
 - [Default repository feature](/git-integration-for-jira-cloud/default-repository-feature-gij-cloud/)
 - [Personal access token feature](/git-integration-for-jira-cloud/personal-access-token-feature-gij-cloud/)
-
-<kbd>Last updated: December 2025</kbd>

--- a/git-integration-for-jira-cloud/using-the-git-service-integration-wizard-gij-cloud.md
+++ b/git-integration-for-jira-cloud/using-the-git-service-integration-wizard-gij-cloud.md
@@ -1,11 +1,22 @@
 ---
-
-title: Using the Git service integration wizard
-description: How to use the Git service integration wizard to connect repositories
+title: "Using the Git service integration wizard"
+description: "How to use the Git service integration wizard to connect repositories"
+product: "Git Integration for Jira Cloud"
+feature: "Using the Git service integration wizard"
+content_type: "integration"
+audience: "admin"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "Jira Administrator"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "integration", "admin"]
 taxonomy:
     category: git-integration-for-jira-cloud
-
 ---
+<kbd>Last updated: March 2026</kbd>
 
 The Git service integration (formerly full feature integration panel) contains special integration for specific git hosts, supports multiple connected repositories, and automates git integration.
 
@@ -57,5 +68,3 @@ For more detailed information on specific integration steps for supported git ho
 [**Next:** Using the Webhook indexing integration wizard](/git-integration-for-jira-cloud/webhook-indexing-integration-gij-cloud)
 
 <p>&nbsp;</p>
-
-<p style="text-align: center; margin: 0; padding: 0;"><kbd>Last updated: December 2025</kbd></p>

--- a/git-integration-for-jira-cloud/using-the-single-git-integration-wizard-gij-cloud.md
+++ b/git-integration-for-jira-cloud/using-the-single-git-integration-wizard-gij-cloud.md
@@ -1,11 +1,22 @@
 ---
-
-title: Using the Single git integration wizard
-description: How to connect single git repositories using the integration wizard
+title: "Using the Single git integration wizard"
+description: "How to connect single git repositories using the integration wizard"
+product: "Git Integration for Jira Cloud"
+feature: "Using the Single git integration wizard"
+content_type: "integration"
+audience: "admin"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "Jira Administrator"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "integration", "admin"]
 taxonomy:
     category: git-integration-for-jira-cloud
-
 ---
+<kbd>Last updated: March 2026</kbd>
 
 Connect specific single git repositories using Git Integration for Jira.
 
@@ -110,5 +121,3 @@ After completing the setup, the wizard indexes the git repository to build chang
 [**Next:** Self-signed HTTPS integration](/git-integration-for-jira-cloud/self-signed-https-integration-gij-cloud)
 
 <p>&nbsp;</p>
-
-<p style="text-align: center; margin: 0; padding: 0;"><kbd>Last updated: December 2025</kbd></p>

--- a/git-integration-for-jira-cloud/using-the-webhooks-indexing-integration-wizard-gij-cloud.md
+++ b/git-integration-for-jira-cloud/using-the-webhooks-indexing-integration-wizard-gij-cloud.md
@@ -1,9 +1,22 @@
 ---
-title: Using the Webhook indexing integration wizard
-description: How to use the Webhook indexing integration wizard for Git Integration for Jira Cloud.
+title: "Using the Webhook indexing integration wizard"
+description: "How to use the Webhook indexing integration wizard for Git Integration for Jira Cloud."
+product: "Git Integration for Jira Cloud"
+feature: "Using the Webhook indexing integration wizard"
+content_type: "reference"
+audience: "all"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "all"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "reference"]
 taxonomy:
     category: git-integration-for-jira-cloud
 ---
+<kbd>Last updated: March 2026</kbd>
 
 Webhook indexing integration enables git servers behind firewalls to send data to Jira. This integration type has limited features, including no branch or pull/merge request creation from Jira.
 
@@ -85,5 +98,3 @@ For detailed information, see [Webhook indexing integration guide](/git-integrat
 - [Using the Git service integration wizard](/git-integration-for-jira-cloud/using-the-git-service-integration-wizard-gij-cloud/)
 
 <p>&nbsp;</p>
-
-<p style="text-align: center; margin: 0; padding: 0;"><kbd>Last updated: December 2025</kbd></p>

--- a/git-integration-for-jira-cloud/view-repository-indexing-logs-gij-cloud.md
+++ b/git-integration-for-jira-cloud/view-repository-indexing-logs-gij-cloud.md
@@ -1,11 +1,22 @@
 ---
-
-title: View repository indexing logs
-description: How to view and download repository indexing logs
+title: "View repository indexing logs"
+description: "How to view and download repository indexing logs"
+product: "Git Integration for Jira Cloud"
+feature: "View repository indexing logs"
+content_type: "integration"
+audience: "all"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "all"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "integration"]
 taxonomy:
     category: git-integration-for-jira-cloud
-
 ---
+<kbd>Last updated: March 2026</kbd>
 
 ![](/wp-content/uploads/gij-gitcloud-actions-view-logs-2025.png)
 
@@ -49,5 +60,3 @@ If you encounter issues, send this log to [gijsupport@gitkraken.com](mailto:gijs
 [Associating project permissions](/git-integration-for-jira-cloud/associating-project-permissions-gij-cloud/) (Git Integration for Jira Cloud)
 
 <p>&nbsp;</p>
-
-<p style="text-align: center; margin: 0; padding: 0;"><kbd>Last updated: December 2025</kbd></p>

--- a/git-integration-for-jira-cloud/viewing-commit-code-diffs-gij-cloud.md
+++ b/git-integration-for-jira-cloud/viewing-commit-code-diffs-gij-cloud.md
@@ -1,11 +1,22 @@
 ---
-
-title: Viewing commit code diffs
-description: How to view commit code differences in Git Integration for Jira Cloud
+title: "Viewing commit code diffs"
+description: "How to view commit code differences in Git Integration for Jira Cloud"
+product: "Git Integration for Jira Cloud"
+feature: "Viewing commit code diffs"
+content_type: "integration"
+audience: "admin"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "Jira Administrator"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "integration", "admin"]
 taxonomy:
     category: git-integration-for-jira-cloud
-
 ---
+<kbd>Last updated: March 2026</kbd>
 
 Access the commit code diff dialog from the following locations:
 
@@ -35,5 +46,3 @@ Each click on the **# lines hidden** label expands up to 20 lines of code in tha
 [**Next:** Git user identity](/git-integration-for-jira-cloud/git-user-identity-gij-cloud)
 
 <p>&nbsp;</p>
-
-<p style="text-align: center; margin: 0; padding: 0;"><kbd>Last updated: December 2025</kbd></p>

--- a/git-integration-for-jira-cloud/web-linking-gij-cloud.md
+++ b/git-integration-for-jira-cloud/web-linking-gij-cloud.md
@@ -1,11 +1,22 @@
 ---
-
-title: Web linking
-description: Configuring web links to your git hosting provider in Git Integration for Jira Cloud
+title: "Web linking"
+description: "Configuring web links to your git hosting provider in Git Integration for Jira Cloud"
+product: "Git Integration for Jira Cloud"
+feature: "Web linking"
+content_type: "integration"
+audience: "all"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "all"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "integration"]
 taxonomy:
     category: git-integration-for-jira-cloud
-
 ---
+<kbd>Last updated: March 2026</kbd>
 
 <b style='background-color:#FFF1B6; padding:1px 5px; color:#172A4C; border-radius:3px; margin: 0 5px; font-size: small;'>OPTIONAL</b>
 
@@ -127,5 +138,3 @@ Web Linking section when editing repository settings.</i></div>
 [**Next:** Linking git commits to Jira issues](/git-integration-for-jira-cloud/smart-commits-gij-cloud)
 
 <p>&nbsp;</p>
-
-<p style="text-align: center; margin: 0; padding: 0;"><kbd>Last updated: December 2025</kbd></p>

--- a/git-integration-for-jira-cloud/webhook-github-organization-support-gij-cloud.md
+++ b/git-integration-for-jira-cloud/webhook-github-organization-support-gij-cloud.md
@@ -1,9 +1,22 @@
 ---
-title: Webhook GitHub Organization support
-description: Configure organization-level webhooks in GitHub to automatically register webhooks for all repositories.
+title: "Webhook GitHub Organization support"
+description: "Configure organization-level webhooks in GitHub to automatically register webhooks for all repositories."
+product: "Git Integration for Jira Cloud"
+feature: "Webhook GitHub Organization support"
+content_type: "reference"
+audience: "admin"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: ["GitHub"]
+role_required: "Jira Administrator"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "reference", "admin", "GitHub"]
 taxonomy:
     category: git-integration-for-jira-cloud
 ---
+<kbd>Last updated: March 2026</kbd>
 
 Git Integration for Jira supports GitHub Organization webhooks. Configure webhooks at the organization level to automatically register webhooks for all repositories, eliminating the need to create individual webhooks for each repository.
 
@@ -39,5 +52,3 @@ Git Integration for Jira supports GitHub Organization webhooks. Configure webhoo
 8. Click **Add webhook**.
 
 All repositories in the organization will now send webhook events to Git Integration for Jira.
-
-<kbd>Last updated: December 2025</kbd>

--- a/git-integration-for-jira-cloud/webhook-indexing-integration-gij-cloud.md
+++ b/git-integration-for-jira-cloud/webhook-indexing-integration-gij-cloud.md
@@ -1,9 +1,22 @@
 ---
-title: Webhook indexing integration
-description: Learn how to configure webhook indexing integration for Git Integration for Jira Cloud to work with git servers behind firewalls.
+title: "Webhook indexing integration"
+description: "Learn how to configure webhook indexing integration for Git Integration for Jira Cloud to work with git servers behind firewalls."
+product: "Git Integration for Jira Cloud"
+feature: "Webhook indexing integration"
+content_type: "concept"
+audience: "admin"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "Jira Administrator"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "concept", "admin"]
 taxonomy:
     category: git-integration-for-jira-cloud
 ---
+<kbd>Last updated: March 2026</kbd>
 
 Webhook indexing integration enables your git servers to work behind a firewall while still sending git data to Jira Cloud.
 
@@ -132,5 +145,3 @@ See [Security & Trust](https://bigbrassband.com/security-and-trust.html).
 ### I have more questions
 
 Contact us at [gijsupport@gitkraken.com](mailto:gijsupport@gitkraken.com) or via our [Support Portal](https://help.gitkraken.com/git-integration-for-jira-cloud/gij-cloud-contact-support/).
-
-<kbd>Last updated: December 2025</kbd>

--- a/git-integration-for-jira-cloud/working-with-custom-api-path-gij-cloud.md
+++ b/git-integration-for-jira-cloud/working-with-custom-api-path-gij-cloud.md
@@ -1,9 +1,22 @@
 ---
-title: Working with Custom API Path
-description: Configure Custom API Path to filter and retrieve specific repositories from GitHub, GitLab, and Bitbucket integrations in Git Integration for Jira Cloud.
+title: "Working with Custom API Path"
+description: "Configure Custom API Path to filter and retrieve specific repositories from GitHub, GitLab, and Bitbucket integrations in Git Integration for Jira Cloud."
+product: "Git Integration for Jira Cloud"
+feature: "Working with Custom API Path"
+content_type: "integration"
+audience: "all"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: ["GitHub", "GitLab", "Bitbucket"]
+role_required: "all"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "integration", "GitHub", "GitLab", "Bitbucket"]
 taxonomy:
     category: git-integration-for-jira-cloud
 ---
+<kbd>Last updated: March 2026</kbd>
 
 The Custom API Path is a relative path that starts with `/`. Use it to filter which repositories Git Integration for Jira retrieves from your git service. The maximum length is **2,000 characters**.
 
@@ -286,5 +299,3 @@ Returns repositories for the specified workspace ID.
     <sup>1</sup> <i>Logo owned by <a href='https://gitlab.com/'>GitLab Inc</a> used under <a href='https://creativecommons.org/licenses/by-nc-sa/4.0/'>license</a>.
     <p>&nbsp;&nbsp;All product names, logos, and brands are property of their respective owners.<p><i>
 </div>
-
-<kbd>Last updated: December 2025</kbd>

--- a/git-integration-for-jira-cloud/working-with-jmespath-filters-gij-cloud.md
+++ b/git-integration-for-jira-cloud/working-with-jmespath-filters-gij-cloud.md
@@ -1,9 +1,22 @@
 ---
-title: Working with JMESPath Filters
-description: Learn how to use JMESPath query language to filter API results and control which repositories are integrated with Jira Cloud.
+title: "Working with JMESPath Filters"
+description: "Learn how to use JMESPath query language to filter API results and control which repositories are integrated with Jira Cloud."
+product: "Git Integration for Jira Cloud"
+feature: "Working with JMESPath Filters"
+content_type: "integration"
+audience: "all"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "all"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "integration"]
 taxonomy:
     category: git-integration-for-jira-cloud
 ---
+<kbd>Last updated: March 2026</kbd>
 
 JMESPath is a query language for JSON. Use JMESPath filters to control which repositories Git Integration for Jira connects to your Jira instance.
 
@@ -54,5 +67,3 @@ JMESPath filters work with these git services:
 - [GitLab.com | GitLab CE/EE JMESPath filter examples](/git-integration-for-jira-cloud/gitlab-com-gitlab-ce-ee-jmespath-filter-examples-gij-cloud)
 - [Microsoft | VSTS | TFS | Azure Repos JMESPath filter examples](/git-integration-for-jira-cloud/microsoft-vsts-tfs-azure-repos-jmespath-filter-examples-gij-cloud)
 - [Bitbucket JMESPath filter examples](/git-integration-for-jira-cloud/bitbucket-jmespath-filter-examples-gij-cloud)
-
-<kbd>Last updated: December 2025</kbd>

--- a/git-integration-for-jira-cloud/working-with-ssh-keys-gij-cloud.md
+++ b/git-integration-for-jira-cloud/working-with-ssh-keys-gij-cloud.md
@@ -1,11 +1,22 @@
 ---
-
-title: Working with SSH keys
-description: How to generate and configure SSH keys for Git Integration for Jira Cloud
+title: "Working with SSH keys"
+description: "How to generate and configure SSH keys for Git Integration for Jira Cloud"
+product: "Git Integration for Jira Cloud"
+feature: "Working with SSH keys"
+content_type: "security"
+audience: "all"
+plan_required: "all"
+deployment: "Jira Cloud"
+git_host_support: []
+role_required: "all"
+version_required: "all"
+status: "GA"
+last_verified: "2026-03"
+tags: ["Git Integration for Jira Cloud", "Jira Cloud", "security"]
 taxonomy:
     category: git-integration-for-jira-cloud
-
 ---
+<kbd>Last updated: March 2026</kbd>
 
 SSH keys provide a secure connection with the remote git host. Git Integration for Jira uses one set of keys for accessing all configured repositories.
 
@@ -285,5 +296,3 @@ If a new SSH key pair is generated for the configured repository, follow these s
 3.  Click **Save** to save the settings.
 
 <p>&nbsp;</p>
-
-<p style="text-align: center; margin: 0; padding: 0;"><kbd>Last updated: December 2025</kbd></p>


### PR DESCRIPTION
Looks like a lot, but it's the same type of change for all files. 
 
- Scope: metadata normalization only
  - Files: 145 markdown docs under git-integration-for-jira-cloud/
  - Excluded intentionally: content rewrites, structure changes, and generated index files