### PR TITLE
Expands GitHub PAT docs for fine-grained tokens

### DIFF
--- a/git-integration-for-jira-cloud/creating-personal-access-tokens-gij-cloud.md
+++ b/git-integration-for-jira-cloud/creating-personal-access-tokens-gij-cloud.md
@@ -21,7 +21,9 @@ taxonomy:
 Personal access tokens (PATs) provide secure authentication for connecting git services to Git Integration for Jira Cloud. This page provides step-by-step instructions for creating PATs on each supported git host.
 
 **On this page:**
-- [Create a GitHub or GitHub Enterprise PAT](#create-a-github-or-github-enterprise-pat)
+- [GitHub and GitHub Enterprise PAT](#github-and-github-enterprise-pat)
+  - [Classic personal access token](#classic-personal-access-token)
+  - [Fine-grained personal access token](#fine-grained-personal-access-token)
 - [Create a GitLab PAT](#create-a-gitlab-pat)
 - [Create an Azure DevOps or VSTS PAT](#create-an-azure-devops-or-vsts-pat)
 - [Create a TFS 2017+ PAT](#create-a-tfs-2017-pat)
@@ -32,7 +34,11 @@ Personal access tokens (PATs) provide secure authentication for connecting git s
 * * *
 &nbsp;
 
-## Create a GitHub or GitHub Enterprise PAT
+## GitHub and GitHub Enterprise PAT
+
+GitHub supports two types of personal access tokens: **Classic** and **Fine-grained**. Use the appropriate section below based on the token type you want to create.
+
+### Classic personal access token
 
 If you enable two-factor authentication for your GitHub account, you must create a PAT to access your git repositories. We recommend enabling two-factor authentication for increased security.
 

--- a/git-integration-for-jira-cloud/creating-personal-access-tokens-gij-cloud.md
+++ b/git-integration-for-jira-cloud/creating-personal-access-tokens-gij-cloud.md
@@ -68,6 +68,29 @@ If you enable two-factor authentication for your GitHub account, you must create
 
 7. Copy the token immediately. This is the only time GitHub displays it.
 
+### Fine-grained personal access token
+
+Fine-grained tokens provide more granular control over which repositories and actions the token can access.
+
+**Minimum required scopes for a read-only integration:**
+
+| Scope | Permission | Purpose |
+|---|---|---|
+| Metadata | Read-only | Required by GitHub on all fine-grained tokens |
+| Contents | Read-only | Repo listing, commits, branches, cloning |
+| Pull requests | Read-only | View pull request data |
+| Issues | Read-only | GitHub treats PRs as a subtype of issues |
+| Actions | Read-only | Workflow/CI data |
+| Deployments | Read-only | Deployment data |
+| Administration | Read-only | Enumerate org repositories |
+
+**Additional scopes for write features (branch/PR creation, branch management):**
+
+| Scope | Permission | Purpose |
+|---|---|---|
+| Pull requests | Read and write | Create and manage pull requests from Jira |
+| Contents | Read and write | Create and manage branches from Jira |
+
 &nbsp;
 * * *
 &nbsp;

--- a/git-integration-for-jira-cloud/github-com-gij-cloud.md
+++ b/git-integration-for-jira-cloud/github-com-gij-cloud.md
@@ -65,6 +65,8 @@ Quickly learn how to connect GitHub.com git repositories via Git Integration for
 **What's on this page:**
 - [Integrate GitHub.com with Jira Cloud](#integrate-githubcom-with-jira-cloud)
   - [Creating a personal access token](#creating-a-personal-access-token)
+    - [Classic personal access token](#classic-personal-access-token)
+    - [Fine-grained personal access token](#fine-grained-personal-access-token)
   - [Using Git service integration](#using-git-service-integration)
   - [Single git repository integration](#single-git-repository-integration)
   - [Setting up GitHub permissions](#setting-up-github-permissions)
@@ -84,6 +86,10 @@ Quickly learn how to connect GitHub.com git repositories via Git Integration for
 
 ## Creating a personal access token
 
+GitHub supports two types of personal access tokens: **Classic** and **Fine-grained**. Both work with Git Integration for Jira.
+
+### Classic personal access token
+
 <div class="bbb-callout bbb--alert">
     <div class="irow">
     <div class="ilogobox">
@@ -97,6 +103,29 @@ Quickly learn how to connect GitHub.com git repositories via Git Integration for
 <br>
 
 While instructions from GitHub works just fine, please [follow this article](/git-integration-for-jira-cloud/creating-personal-access-tokens-gij-cloud) for a quick step-by-step guide to get you started.
+
+### Fine-grained personal access token
+
+Fine-grained tokens provide more granular control over which repositories and actions the token can access. For setup instructions, see [this article](/git-integration-for-jira-cloud/creating-personal-access-tokens-gij-cloud).
+
+**Minimum required scopes for a read-only integration:**
+
+| Scope | Permission | Purpose |
+|---|---|---|
+| Metadata | Read-only | Required by GitHub on all fine-grained tokens |
+| Contents | Read-only | Repo listing, commits, branches, cloning |
+| Pull requests | Read-only | View pull request data |
+| Issues | Read-only | GitHub treats PRs as a subtype of issues |
+| Actions | Read-only | Workflow/CI data |
+| Deployments | Read-only | Deployment data |
+| Administration | Read-only | Enumerate org repositories |
+
+**Additional scopes for write features (branch/PR creation, branch management):**
+
+| Scope | Permission | Purpose |
+|---|---|---|
+| Pull requests | Read and write | Create and manage pull requests from Jira |
+| Contents | Read and write | Create and manage branches from Jira |
 
 ## Using Git service integration
 

--- a/git-integration-for-jira-cloud/github-enterprise-server-gij-cloud.md
+++ b/git-integration-for-jira-cloud/github-enterprise-server-gij-cloud.md
@@ -66,6 +66,8 @@ Quickly learn how to connect GitHub Enterprise Server git repositories via Git I
 **What's on this page:**
 - [Integrate GitHub Enterprise Server with Jira Cloud](#integrate-github-enterprise-server-with-jira-cloud)
   - [Creating a personal access token](#creating-a-personal-access-token)
+    - [Classic personal access token](#classic-personal-access-token)
+    - [Fine-grained personal access token](#fine-grained-personal-access-token)
   - [Using Git service integration](#using-git-service-integration)
   - [Single git repository integration](#single-git-repository-integration)
   - [Setting up GitHub Enterprise Server permissions](#setting-up-github-enterprise-server-permissions)


### PR DESCRIPTION
Fixes #257
Expands the GitHub Personal Access Token (PAT) documentation to include support and details for GitHub's new fine-grained tokens.

- Refactors the main PAT creation article to clearly distinguish between Classic and Fine-grained PATs.
- Adds comprehensive instructions for creating fine-grained tokens, including minimum required scopes for read-only and additional scopes for write functionalities (e.g., branch/PR creation).
- Updates the GitHub.com and GitHub Enterprise Server integration guides to reference and link to the new fine-grained PAT information.